### PR TITLE
chore: Remove vim-terraform

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,9 +58,6 @@
 [submodule "vim/bundle/vim-terraform"]
 	path = vim/bundle/vim-terraform
 	url = https://github.com/hashivim/vim-terraform.git
-[submodule "nvim/pack/nvim/start/vim-terraform"]
-	path = nvim/pack/nvim/start/vim-terraform
-	url = https://github.com/hashivim/vim-terraform.git
 [submodule "nvim/pack/nvim/start/nvim-surround"]
 	path = nvim/pack/nvim/start/nvim-surround
 	url = https://github.com/kylechui/nvim-surround.git


### PR DESCRIPTION
**Description:**

Remove vim-terraform plugin from nvim

**Related Issues:**

Fixes #90

**Checklist:**

- [ ] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
