### PR TITLE
feat: Add bash-language-server

### DIFF
--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -58,6 +58,12 @@ cmp.setup({
 local cmp_capabilities = cmp_nvim_lsp.default_capabilities()
 -- }}}
 
+-- {{{ bash-language-server
+lspconfig.bashls.setup({
+	capabilities = cmp_capabilities,
+})
+-- }}}
+
 -- efm-langserver {{{
 
 -- formatters {{{
@@ -88,8 +94,6 @@ lspconfig.efm.setup({
 			--       golangci-lint isn't used because I usually have specific
 			--       configuration per-project and checks analysis tools built
 			--       into gopls are usually good enough for normal editing.
-			-- TODO(#16): Formatting/linting support for SQL
-			-- TODO(#16): Formatting/linting support for shell with shfmt,shellcheck
 			javascript = { prettier },
 			json = { prettier },
 			json5 = { prettier },

--- a/nvim/lua/ianlewis/init.lua
+++ b/nvim/lua/ianlewis/init.lua
@@ -23,8 +23,6 @@ require("ianlewis.remap")
 vim.api.nvim_create_autocmd("BufWritePre", {
 	callback = function()
 		local mode = vim.api.nvim_get_mode().mode
-		-- TODO(#16): Does this need to check if it's a normal file buffer?
-		-- TODO(#16): This doesn't seem to always work on file save.
 		if vim.bo.modified == true and mode == "n" then
 			vim.cmd("lua vim.lsp.buf.format()")
 		end

--- a/nvim/lua/ianlewis/mason.lua
+++ b/nvim/lua/ianlewis/mason.lua
@@ -58,6 +58,9 @@ require("mason").setup({
 require("mason-lspconfig").setup({
 	-- Ensure LSP servers are installed.
 	ensure_installed = {
+		-- bash-language-server
+		"bashls",
+
 		-- efm-langserver
 		"efm",
 
@@ -92,6 +95,8 @@ require("mason-tool-installer").setup({
 		"prettier",
 		"stylua",
 		"selene",
+		"shellcheck",
+		"shfmt",
 		"yamllint",
 		-- TODO(#95): install terraform with Aqua
 	},


### PR DESCRIPTION
**Description:**

Add `bash-language-server` with `shfmt` and `shellcheck` support.

**Related Issues:**

Fixes #16 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
