### PR TITLE
fix: cpu/ram bg color

### DIFF
--- a/tmux/_tmux.conf
+++ b/tmux/_tmux.conf
@@ -55,7 +55,7 @@ set -g @ram_high_bg_color "red"
 
 # We need to do a full overwrite of the status-right from tokyonight_moon.tmux
 # to include the cpu/ram values.
-set -g status-right "#[fg=#1e2030,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#1e2030] #{prefix_highlight} #[fg=#3b4261,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#3b4261] %Y-%m-%d  %H:%M #[fg=#{cpu_bg_color},bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#{cpu_bg_color},bold] #{cpu_icon} #{cpu_percentage} #[fg=#82aaff,bg=#{cpu_bg_color},nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#{ram_bg_color},bold] #{ram_icon} #{ram_percentage} #[fg=#82aaff,bg=#{ram_bg_color},nobold,nounderscore,noitalics]#[fg=#1b1d2b,bg=#82aaff,bold] #h "
+set -g status-right "#[fg=#1e2030,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#1e2030] #{prefix_highlight} #[fg=#3b4261,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#3b4261] %Y-%m-%d  %H:%M #[fg=#{cpu_bg_color},bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#{cpu_bg_color},bold] #{cpu_icon} #{cpu_percentage} #[fg=#{ram_bg_color},bg=#{cpu_bg_color},nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#{ram_bg_color},bold] #{ram_icon} #{ram_percentage} #[fg=#82aaff,bg=#{ram_bg_color},nobold,nounderscore,noitalics]#[fg=#1b1d2b,bg=#82aaff,bold] #h "
 
 # Plugins
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
**Description:**

Fix bg color for cpu and ram separator when they are different colors.

**Related Issues:**

n/a

**Checklist:**

- [ ] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
