### PR TITLE
fix: number-only session name

### DIFF
--- a/bin/all/tmux-sessionizer
+++ b/bin/all/tmux-sessionizer
@@ -33,6 +33,11 @@ fi
 selected_name=$(basename "$selected" | tr . _)
 tmux_running=$(pgrep tmux)
 
+# Session name can't be a number so add a trailing underscore.
+if [[ ${selected_name} =~ ^[0-9]+$ ]]; then
+    selected_name="${selected_name}_"
+fi
+
 if [[ -z $TMUX ]] && [[ -z ${tmux_running} ]]; then
     tmux new-session -s "${selected_name}" -c "${selected}"
     tmux new-window -t "${selected_name}" -c "${selected}" \; \


### PR DESCRIPTION
**Description:**

Fix number-only Tmux session names

**Related Issues:**

n/a

**Checklist:**

- [ ] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
