### PR TITLE
chore: Remove old golangci-lint PATH config

### DIFF
--- a/bash/_bashrc
+++ b/bash/_bashrc
@@ -220,12 +220,6 @@ for d in "${HOME}"/.gem/ruby/*/bin; do
     [[ ":$PATH:" != *":${d}:"* ]] && PATH="${d}:${PATH}"
 done
 
-# path for golangci-lint
-GOLANGCILINT_PATH=$(find "${HOME}/opt" -maxdepth 1 -type d -name "golangci-lint-*" | sort -Vr | head -n1)
-if [ "${GOLANGCILINT_PATH}" != "" ]; then
-    PATH="${GOLANGCILINT_PATH}:${PATH}"
-fi
-
 # The next line updates PATH for the Google Cloud SDK.
 if [ -f "$HOME/opt/google-cloud-sdk/path.bash.inc" ]; then
     # shellcheck source=/dev/null


### PR DESCRIPTION
**Description:**

Remove old golangci-lint PATH config from bashrc

**Related Issues:**

Fixes #157 

**Checklist:**

- [ ] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
