### PR TITLE
fix: Reopen folds at cursor position

### DIFF
--- a/nvim/lua/ianlewis/autocmd.lua
+++ b/nvim/lua/ianlewis/autocmd.lua
@@ -17,6 +17,12 @@
 vim.api.nvim_create_autocmd("BufWritePre", {
 	callback = function()
 		vim.lsp.buf.format()
+		-- Reopen the fold at the cursor position. The result is that formatting
+		-- the file will close all folds other that the one at the cursor
+		-- position.
+		if vim.opt.foldenable then
+			vim.cmd("normal! zv")
+		end
 	end,
 })
 -- }}}


### PR DESCRIPTION
**Description:**

Reopen folds at the cursor position after formatting the file.

**Related Issues:**

Fixes #142 

**Checklist:**

- [ ] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
