### PR TITLE
fix: disable tree sitter for latex

### DIFF
--- a/nvim/after/plugin/treesitter.lua
+++ b/nvim/after/plugin/treesitter.lua
@@ -63,6 +63,8 @@ require("nvim-treesitter.configs").setup({
 
 	highlight = {
 		enable = true,
+		-- TODO(#78): Latex needs the treesitter CLI.
+		disable = { "latex" },
 
 		-- Setting this to true will run `:h syntax` and tree-sitter at the same time.
 		-- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).


### PR DESCRIPTION
**Description:**

Disable running tree sitter for Latex files since it requires the tree-sitter CLI.

**Related Issues:**

n/a

**Checklist:**

- [ ] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
