### PR TITLE
fix: slsa-verifier install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -540,7 +540,7 @@ $(HOME)/opt/slsa-verifier-v$(SLSA_VERIFIER_VERSION)/slsa-verifier: $(HOME)/opt
 		mv "$${tempfile}" $(HOME)/opt/slsa-verifier-v$(SLSA_VERIFIER_VERSION)/slsa-verifier; \
 		chmod +x $(HOME)/opt/slsa-verifier-v$(SLSA_VERIFIER_VERSION)/slsa-verifier
 
-$(HOME)/bin/slsa-verifier: $(HOME)/opt/slsa-verifier-v$(SLSA_VERIFIER_VERSION)/slsa-verifier
+$(HOME)/bin/slsa-verifier: $(HOME)/bin $(HOME)/opt/slsa-verifier-v$(SLSA_VERIFIER_VERSION)/slsa-verifier
 	@set -euo pipefail; \
 		ln -sf $(HOME)/opt/slsa-verifier-v$(SLSA_VERIFIER_VERSION)/slsa-verifier $@; \
 		touch $(HOME)/opt/slsa-verifier-v$(SLSA_VERIFIER_VERSION)/slsa-verifier


### PR DESCRIPTION
**Description:**

Fix `slsa-verifier` install when `~/bin` doesn't exist.

**Related Issues:**

n/a

**Checklist:**

- [ ] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
