### PR TITLE
fix: Run slsa-verifier using abs path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -555,7 +555,7 @@ $(HOME)/opt/aqua-v$(AQUA_VERSION)/.installed: $(HOME)/opt $(HOME)/bin/slsa-verif
 		tempjsonl=$$(mktemp --suffix=".aqua-v$(AQUA_VERSION).intoto.jsonl"); \
 		curl -sSLo "$${tempfile}" "$(AQUA_URL)"; \
 		curl -sSLo "$${tempjsonl}" "$(AQUA_PROVENANCE_URL)"; \
-		slsa-verifier verify-artifact \
+		$(HOME)/bin/slsa-verifier verify-artifact \
 			"$${tempfile}" \
 			--provenance-path "$${tempjsonl}" \
 			--source-uri "$(AQUA_REPO)" \


### PR DESCRIPTION
**Description:**

Run `slsa-verifier` using full path rather than relying on `$PATH` which may not be set of first install.

**Related Issues:**

n/a

**Checklist:**

- [ ] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
