### PR TITLE
fix: configure-efm-langserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -501,7 +501,7 @@ $(HOME)/.config/efm-langserver/config.yaml: efm-langserver/config.yaml
 	@set -euo pipefail; \
 		mkdir -p $$(dirname $@); \
 		mkdir -p $(HOME)/.local/var/log; \
-		envsubst < $< > $@
+		sed 's|$${HOME}|'"$${HOME}"'|'< $< > $@
 
 .PHONY: configure-efm-langserver
 configure-efm-langserver: $(HOME)/.config/efm-langserver/config.yaml ## Configure efm-langserver.


### PR DESCRIPTION
**Description:**

Fix configuring `efm-langserver` so that it doesn't use `envsubst`

**Related Issues:**

n/a

**Checklist:**

- [ ] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
