### PR TITLE
feat: Make scrolloff 15 lines

### DIFF
--- a/nvim/lua/ianlewis/options.lua
+++ b/nvim/lua/ianlewis/options.lua
@@ -45,7 +45,7 @@ vim.opt.statusline =
 vim.opt.incsearch = true
 
 -- Always keep this many lines visible above and below the cursor.
-vim.opt.scrolloff = 8
+vim.opt.scrolloff = 15
 
 -- Always show the signcolumn so it's not jittering the screen when there
 -- are errors in the file.


### PR DESCRIPTION
**Description:**

Make `vim.opt.scrolloff` 15 lines to give more context around code.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
