### PR TITLE
fix: leaking characters in wezterm

### DIFF
--- a/tmux/_tmux.conf
+++ b/tmux/_tmux.conf
@@ -31,7 +31,7 @@ unbind h
 bind h split-window
 
 # Make the current pane small.
-bind z resize-pane -x 80; 
+bind z resize-pane -x 80;
 
 
 # Options
@@ -79,3 +79,11 @@ set -g @plugin 'tmux-plugins/tmux-cpu'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'
+
+# Set the timeout after an escape is input to determine if it is part of a
+# function or meta key sequences. This fixes issues with tmux causing terminal
+# characters to leak into the terminal.
+# See: https://github.com/wezterm/wezterm/issues/2060
+#
+# This must be set *after* tmux-sensible because it overrides the tmux default.
+set -sg escape-time 500


### PR DESCRIPTION
**Description:**

Fix leaking tmux control characters into wezterm.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
