### PR TITLE
feat: Add nix.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ help: ## Print all Makefile targets (this message).
 all: install-all configure-all ## Install and configure everything.
 
 .PHONY: configure-all
-configure-all: configure-aqua configure-efm-langserver configure-nvim configure-bash configure-git configure-tmux ## Configure all tools.
+configure-all: configure-aqua configure-efm-langserver configure-nix configure-nvim configure-bash configure-git configure-tmux ## Configure all tools.
 
 .PHONY: install-all
 install-all: install-aqua ## Install all tools.
@@ -540,6 +540,12 @@ $(HOME)/.config/efm-langserver/config.yaml: efm-langserver/config.yaml
 
 .PHONY: configure-efm-langserver
 configure-efm-langserver: $(HOME)/.config/efm-langserver/config.yaml ## Configure efm-langserver.
+
+.PHONY: configure-nix
+configure-nix: ## Configure nix.
+	@set -euo pipefail; \
+		rm -f ~/.config/nix; \
+		ln -sf $(REPO_ROOT)/nix ~/.config/nix
 
 .PHONY: configure-nvim
 configure-nvim: ## Configure neovim.

--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -1,0 +1,16 @@
+# vim:ft=nix
+# Copyright 2025 Ian Lewis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+experimental-features = nix-command flakes


### PR DESCRIPTION
**Description:**

Add a `nix.conf` to enable flakes by default.

**Related Issues:**

Fixes #206 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
