### PR TITLE
fix: Add `GH_TOKEN` to `make all` pre-submit

### DIFF
--- a/.github/workflows/pre-submit.units.yml
+++ b/.github/workflows/pre-submit.units.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           node-version-file: "package.json"
       - name: Install all
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make clean all
 
   # Check license headers


### PR DESCRIPTION
**Description:**

Add `GH_TOKEN` to the `make all` pre-submit to allow Aqua to verify GitHub attestations.

**Related Issues:**

Fixes #224 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
