### PR TITLE
fix: remap `signature_help` to `C-k`

### DIFF
--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -24,7 +24,7 @@ vim.api.nvim_create_autocmd("LspAttach", {
 		vim.keymap.set("n", "gd", vim.lsp.buf.definition, bufopts)
 		vim.keymap.set("n", "gi", vim.lsp.buf.implementation, bufopts)
 		vim.keymap.set("n", "K", vim.lsp.buf.hover, bufopts)
-		vim.keymap.set("i", "<C-h>", vim.lsp.buf.signature_help, bufopts)
+		vim.keymap.set("i", "<C-k>", vim.lsp.buf.signature_help, bufopts)
 		vim.keymap.set("n", "<leader>f", vim.lsp.buf.format, bufopts)
 	end,
 })


### PR DESCRIPTION
**Description:**

Remap `vim.lsp.buf.signature_help` to `C-k`.

**Related Issues:**

Fixes #197 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
