### PR TITLE
chore: remove wttr segment

### DIFF
--- a/bash/sbp/settings.conf
+++ b/bash/sbp/settings.conf
@@ -23,7 +23,7 @@ else
     # TODO(github.com/brujoand/sbp/issues/135): Enable the k8s segment when it
     #                                           doesn't depend on pcregrep.
     SBP_SEGMENTS_LEFT=('host' 'path' 'python_env' 'git' 'nix')
-    SBP_SEGMENTS_RIGHT=('command' 'exit_code' 'load' 'timestamp' 'wttr')
+    SBP_SEGMENTS_RIGHT=('command' 'exit_code' 'load' 'timestamp')
     SBP_SEGMENTS_LINE_TWO=('prompt_ready')
 fi
 


### PR DESCRIPTION
**Description:**

Remove the `wttr` segment because it often fails. Wttr seems to return 200 HTTP status responses even when errors occur so it's hard to determine if the response is an error.

**Related Issues:**

n/a

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
