### PR TITLE
chore: update nix.conf link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -656,8 +656,8 @@ configure-efm-langserver: $(XDG_CONFIG_HOME)/efm-langserver/config.yaml ## Confi
 .PHONY: configure-nix
 configure-nix: ## Configure nix.
 	@set -euo pipefail; \
-		rm -f $(XDG_CONFIG_HOME)/nix; \
-		ln -sf $(REPO_ROOT)/nix $(XDG_CONFIG_HOME)/nix
+		mkdir -p $(XDG_CONFIG_HOME)/nix; \
+		ln -sf $(REPO_ROOT)/nix/nix.conf $(XDG_CONFIG_HOME)/nix/nix.conf
 
 .PHONY: configure-nvim
 configure-nvim: ## Configure neovim.


### PR DESCRIPTION
**Description:**

Update `nix.conf` link so that a link is created directly to `nix.conf` rather than creating a link at `~/.local/state/nix`

**Related Issues:**

Fixes #289 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
