### PR TITLE
fix: treesitter parser compilation

### DIFF
--- a/nvim/after/plugin/treesitter.lua
+++ b/nvim/after/plugin/treesitter.lua
@@ -15,6 +15,9 @@
 -- e.g. ~/.local/share/nvim/treesitter
 local parser_dir = vim.fn.stdpath("data") .. "/treesitter"
 
+-- NOTE: treesitter parser dir must be added to the runtime path.
+vim.opt.runtimepath:append(parser_dir)
+
 require("nvim-treesitter.configs").setup({
 	-- A list of parser names, or "all" (the listed parsers MUST always be installed)
 	ensure_installed = {
@@ -82,6 +85,3 @@ require("nvim-treesitter.configs").setup({
 		additional_vim_regex_highlighting = false,
 	},
 })
-
--- NOTE: treesitter parser dir must be added to the runtime path.
-vim.opt.runtimepath:append(parser_dir)


### PR DESCRIPTION
**Description:**

Fix setting the treesitter parsers directory. The directory must be added to the vim runtime path before calling `treesitter.setup`. Otherwise, treesitter will recompile all the parsers every time Neovim starts.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
