### PR TITLE
fix: Update node CLI tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -774,7 +774,7 @@ nodenv/package-lock.json: nodenv/package.json
 			--no-fund
 
 # Installs tools in the user node_modules.
-$(XDG_DATA_HOME)/node_modules/.installed: $(NODENV_ROOT)/.installed
+$(XDG_DATA_HOME)/node_modules/.installed: nodenv/package-lock.json $(NODENV_ROOT)/.installed
 	@set -euo pipefail; \
 		cd $(REPO_ROOT)/nodenv; \
 		NODENV_ROOT=$(NODENV_ROOT) $(NODENV_ROOT)/shims/npm clean-install; \


### PR DESCRIPTION
**Description:**

Update node CLI tools when running `make install-node`

**Related Issues:**

n/a

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
