### PR TITLE
chore(deps): enable git submodule updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -37,6 +37,11 @@
     enabled: true,
   },
 
+  // Enable git submodule updates.
+  "git-submodules": {
+    enabled: true,
+  },
+
   // Create a new issue for each config warning. By default, Renovate re-opens
   // an existing issue which can be very old and is easily missed. Opening new
   // issues is more intuitive.


### PR DESCRIPTION
**Description:**

Allow renovate to update git submodules. This will allow renovate to update vim plugins.

**Related Issues:**

Fixes #352 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
