### PR TITLE
fix: run nvim in a full interactive shell

### DIFF
--- a/bin/all/project-windowizer
+++ b/bin/all/project-windowizer
@@ -33,7 +33,9 @@ function _main() {
     local new_window_size=$(($(tmux display-message -p "#{window_width}") - 80))
 
     # Run the command in the right pane, defaulting to `nvim`.
-    tmux split-window -hd -l "${new_window_size}" "${*:-nvim}"
+    # Explicitly start nvim in an interactive bash shell to ensure the command
+    # runs with a full terminal environment.
+    tmux split-window -hd -l "${new_window_size}" "${*:-"bash -i -c nvim"}"
 
     # clear the left window
     clear


### PR DESCRIPTION
**Description:**

Run nvim via `project-windowizer` in a full interactive bash shell so that it has access to programs installed in pyenv etc.

**Related Issues:**

n/a

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
