### PR TITLE
feat: set Python textwidth to 88

### DIFF
--- a/nvim/after/ftplugin/python.lua
+++ b/nvim/after/ftplugin/python.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 Ian Lewis
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Python-specific options.
+
+-- Set textwidth to align with ruff settings.
+vim.opt.textwidth = 88


### PR DESCRIPTION
**Description:**

Set the `textwidth` option for Python files to 88 to align with settings for the ruff linter/formatter.

**Related Issues:**

n/a

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
