### PR TITLE
fix: ignore ruff flake8-fixme rules

### DIFF
--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -246,23 +246,22 @@ lspconfig.pylsp.setup({
 	settings = {
 		pylsp = {
 			plugins = {
-				-- pycodestyle, pyflakes, mccabe, autopep8, and yapf are disabled by ruff.
+				-- `pycodestyle`, `pyflakes`, `mccabe`, `autopep8`, and `yapf`
+				-- are disabled by ruff.
 				ruff = {
 					enabled = true,
 					-- Enable all rules and exclude rules explicitly.
 					-- https://docs.astral.sh/ruff/rules/
 					select = { "ALL" },
-				},
-				pycodestyle = {
-					-- Use ruff's max line length.
-					maxLineLength = 88,
+					-- Ignore `flake8-fixme` rules. These are handled by
+					-- `todos`.
+					ignore = { "FIX" },
 				},
 			},
 		},
 	},
 })
 --}}}
-
 -- rust-analyzer {{{
 lspconfig.rust_analyzer.setup({
 	capabilities = cmp_capabilities,


### PR DESCRIPTION
**Description:**

Ignore `ruff` `flake8-fixme` rules. These are handled by `todos` via `efm-langserver`.

**Related Issues:**

Fixes #256 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
