### PR TITLE
fix: `$PS1` unbound variable errors

### DIFF
--- a/bash/_bashrc
+++ b/bash/_bashrc
@@ -63,18 +63,16 @@ function _bashrc_main() {
         fi
     fi
 
-    # If not running interactively, don't do anything
-    [ -z "${PS1}" ] && return
+    # If not running interactively, don't do anything. PS1 may be unbound so we
+    # need to use a special form of parameter expansion.
+    [ -z "${PS1+x}" ] && return
 
     # Load system bashrc
+    # NOTE: On Debian based systems /etc/bash.bashrc is loaded before ~/.bashrc
+    #       `-DSYS_BASHRC` compile-time option and does not need to be sourced here.
     if [ -f /etc/bashrc ]; then
         # shellcheck source=/dev/null
         source /etc/bashrc
-    fi
-    # for some debian systems
-    if [ -f /etc/bash.bashrc ]; then
-        # shellcheck source=/dev/null
-        source /etc/bash.bashrc
     fi
 
     EDITOR=vim


### PR DESCRIPTION
**Description:**

Fix `$PS1` unbound variable errors when piping `make` commands.

**Related Issues:**

Fixes #395

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
