### PR TITLE
chore: disable nvim remote plugin providers

### DIFF
--- a/nvim/lua/ianlewis/globals.lua
+++ b/nvim/lua/ianlewis/globals.lua
@@ -27,4 +27,12 @@ do
 		"shell=sh",
 		"typescript",
 	}
+
+	-- Disable unnecessary language providers.
+	-- These providers allow the use of remote plugins written in other
+	-- languages but I don't use any that require them.
+	vim.g.loaded_node_provider = 0
+	vim.g.loaded_perl_provider = 0
+	vim.g.loaded_python3_provider = 0
+	vim.g.loaded_ruby_provider = 0
 end


### PR DESCRIPTION
**Description:**

Disable Neovim remote plugin providers for Node, Ruby, Python, and Perl. I don't use any plugins that require these providers.

**Related Issues:**

Fixes #436

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
