### PR TITLE
fix: init *env even if shims directory in PATH

### DIFF
--- a/bash/_bashrc
+++ b/bash/_bashrc
@@ -200,9 +200,7 @@ function _bashrc_main() {
     export PYENV_ROOT="${XDG_DATA_HOME}/pyenv"
     if [ -d "${PYENV_ROOT}/bin" ]; then
         [[ ":$PATH:" != *":${PYENV_ROOT}/bin:"* ]] && PATH="${PYENV_ROOT}/bin:${PATH}"
-        if [[ ":$PATH:" != *":${PYENV_ROOT}/shims:"* ]]; then
-            eval "$(pyenv init - bash)"
-        fi
+        eval "$(pyenv init - bash)"
     fi
 
     # Activate the 'ian' virtualenv if it exists.
@@ -214,9 +212,7 @@ function _bashrc_main() {
     export NODENV_ROOT="${XDG_DATA_HOME}/nodenv"
     if [ -d "${NODENV_ROOT}/bin" ]; then
         [[ ":$PATH:" != *":${NODENV_ROOT}/bin:"* ]] && PATH="${NODENV_ROOT}/bin:${PATH}"
-        if [[ ":$PATH:" != *":${NODENV_ROOT}/shims:"* ]]; then
-            eval "$(nodenv init - bash)"
-        fi
+        eval "$(nodenv init - bash)"
     fi
 
     # Activate the local node_modules.
@@ -228,9 +224,7 @@ function _bashrc_main() {
     export RBENV_ROOT="${XDG_DATA_HOME}/rbenv"
     if [ -d "${RBENV_ROOT}/bin" ]; then
         [[ ":$PATH:" != *":${RBENV_ROOT}/bin:"* ]] && PATH="${RBENV_ROOT}/bin:${PATH}"
-        if [[ ":$PATH:" != *":${RBENV_ROOT}/shims:"* ]]; then
-            eval "$(rbenv init - bash)"
-        fi
+        eval "$(rbenv init - bash)"
     fi
 
     # The next line updates PATH for the Google Cloud SDK.


### PR DESCRIPTION
**Description:**

Fix `rbenv`,`pyenv`,`nodenv`. Each should have `init` run even if their respective `shims` directory is in the `$PATH`. The `$PATH` is sometimes carried over into interactive sub-shells, so the `shims` directory is on the `$PATH` but the environment is otherwise not set up.

**Related Issues:**

n/a

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
