### PR TITLE
docs: remove references to Mason

### DIFF
--- a/nvim/README.md
+++ b/nvim/README.md
@@ -8,20 +8,19 @@ This directory contains my Neovim configuration. It gets symbolically linked to
 ## Features
 
 - [Tokyo Night](https://github.com/folke/tokyonight.nvim) color scheme.
-- Auto-formatting code on save.
-- Auto-installation and configuration of required linting tools, formatting
-  tools, and LSP servers via [Mason](https://github.com/mason-org/mason.nvim)
-  and
-  [`mason-lspconfig.nvim`](https://github.com/mason-org/mason-lspconfig.nvim).
+- Auto-formatting code on save and completion via LSP servers.
 - LSP server support for:
-    - [`efm-langserver`](https://github.com/mattn/efm-langserver) (formatting,
-      linting): `css`, `html`, `javascript`, `json`, `json5`, `markdown`,
-      `liquid`, `lua`, `scss`, `terraform`, `typescript`, `yaml`, and GitHub
-      Actions workflows (YAML).
+    - [`bash-language-server`](https://github.com/bash-lsp/bash-language-server):
+      LSP server for Bash supporting `shellcheck` and `shfmt`.
+    - [`efm-langserver`](https://github.com/mattn/efm-langserver): Formatting
+      and linting for a variety languages via CLI tools.
     - [`eslint-language-server`](https://github.com/hrsh7th/vscode-langservers-extracted):
       Linting and auto-fixing for `javascript` and `typescript`.
     - [`gopls`](https://github.com/golang/tools/tree/master/gopls): LSP server
       for Go.
+    - [`harper-ls`](https://writewithharper.com/docs/integrations/language-server):
+      LSP server for the [Harper](https://writewithharper.com/) grammar and
+      spelling checker.
     - [`lua-language-server`](https://github.com/luals/lua-language-server): LSP
       server for Lua.
     - [`python-lsp-server`](https://github.com/python-lsp/python-lsp-server):
@@ -29,9 +28,8 @@ This directory contains my Neovim configuration. It gets symbolically linked to
     - [`rust-analyzer`](https://rust-analyzer.github.io/): LSP server for Rust.
     - [`typescript-language-server`](https://github.com/typescript-language-server/typescript-language-server):
       LSP server for TypeScript.
-
 - Convenient [key mappings](./lua/ianlewis/remap.lua) for common actions.
-- Language specific file type settings in [`after/ftplugin`](./after/ftplugin).
+- Language specific filetype settings in [`after/ftplugin`](./after/ftplugin).
 - Status line by [`lualine.nvim`](https://github.com/nvim-lualine/lualine.nvim).
 - Syntax highlighting and language introspection support via
   [`nvim-treesitter`](https://github.com/nvim-treesitter/nvim-treesitter).
@@ -50,9 +48,11 @@ This directory contains my Neovim configuration. It gets symbolically linked to
 
 ## Installation
 
-All tools required for plugins should be installed automatically at startup.
+All tools required for plugins should be installed via the Makefile. See the
+root [`README.md`](../README.md#install) for details.
 
-You do need to compile the `telescope-fzf-native.nvim` plugin manually.
+After installation, you do need to compile the `telescope-fzf-native.nvim`
+plug-in manually to get improved performance for search.
 
 ```shell
 $ cd nvim/pack/nvim/start/telescope-fzf-native.nvim
@@ -65,37 +65,20 @@ cc -O3 -Wall -fpic -std=gnu99 -shared src/fzf.c -o build/libfzf.so
 
 ### `after/plugin`
 
-This directory contains files that configure various plugins.
+[`after/plugin`](after/plugin/) contains files that configure various plugins.
 
 ### `after/ftplugin`
 
-`after/ftplugin/` contains files that set file type specific options.
+[`after/ftplugin/`](after/ftplugin/) contains files that set filetype specific
+options.
 
 ### `lua/ianlewis`
 
-`lua/ianlewis` contains setup for mason packages, global options, filetypes,
-colors, key remappings, etc.
+[`lua/ianlewis`](lua/ianlewis/) contains configuration for global options,
+filetypes, colors, key remappings, etc.
 
 ### `pack/nvim/start`
 
-`pack/nvim/start` contains git submodules for the various plugins that I use.
-These are loaded automatically at startup. The plugins are then configured by
-code in `after/plugin`.
-
-## LSP Servers
-
-LSP Servers are installed as
-[`mason.nvim`](https://github.com/williamboman/mason.nvim) packages via
-[`mason-lspconfig`](https://github.com/williamboman/mason-lspconfig.nvim). This
-configures the servers to work with
-[`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig).
-
-- `bash-language-server`
-- `efm-langserver`
-- `gopls`
-- `lua-language-server`
-- `python-lsp-server`
-- `rust_analyzer`
-- `vscode-eslint-language-server`
-- `typescript-language-server`
-- [`undotree`](https://github.com/mbbill/undotree)
+[`pack/nvim/start`](pack/nvim/start) contains git submodules for the various
+plugins that I use. These are loaded automatically at startup. The plugins are
+then configured by code in `after/plugin`.

--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -265,6 +265,7 @@ lspconfig.pylsp.setup({
 	},
 })
 --}}}
+
 -- rust-analyzer {{{
 lspconfig.rust_analyzer.setup({
 	capabilities = cmp_capabilities,


### PR DESCRIPTION
**Description:**

Remove references to Mason from the Neovim README because Mason is no longer used.

**Related Issues:**

Fixes #456 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
