### PR TITLE
feat: set bat theme

### DIFF
--- a/bash/_bash_completion
+++ b/bash/_bash_completion
@@ -35,6 +35,12 @@ function _bash_completion() {
         source <(aqua completion bash)
     fi
 
+    # bat completion
+    if command -v bat >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        source <(bat --completion bash)
+    fi
+
     # GitHub CLI completion
     if command -v gh >/dev/null 2>&1; then
         # shellcheck source=/dev/null

--- a/bash/_bashrc
+++ b/bash/_bashrc
@@ -140,6 +140,9 @@ function _bashrc_main() {
     export LESS="qR -F -X ${LESS}"
     export LESS
 
+    # Set the bat theme.
+    export BAT_THEME="tokyonight_moon"
+
     local bash_lib_dir="${HOME}/.local/share/bash/lib"
     local nvim_plugin_dir="${HOME}/.config/nvim/pack/nvim/start"
 

--- a/git/_gitconfig
+++ b/git/_gitconfig
@@ -35,3 +35,5 @@
 [delta]
     navigate = true     # use n and N to move between diff sections
     line-numbers = true # show line numbers
+    # NOTE: Uses the bat theme.
+    syntax-theme = tokyonight_moon


### PR DESCRIPTION
**Description:**

Set the theme for `bat`. This also add bash completion for `bat` and sets the `syntax-theme` for `delta`.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
