### PR TITLE
feat: add tree-sitter CLI

### DIFF
--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -2151,6 +2151,36 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/tree-sitter/tree-sitter/v0.25.10/tree-sitter-linux-arm64.gz",
+      "checksum": "07FBFF8AE0EEB0D3E496E14FC1A30DCC730CC2C97D70E601E5357F2E51958AF5",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tree-sitter/tree-sitter/v0.25.10/tree-sitter-linux-x64.gz",
+      "checksum": "8283DDBA69253C698F6E987BA0E2F9285E079C8DB4D36EBE1394B5BB3A0EBDFD",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tree-sitter/tree-sitter/v0.25.10/tree-sitter-macos-arm64.gz",
+      "checksum": "A6295D469669F6E901B6029AE6C129BD094DF582D278C237FADA413505CB9C42",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tree-sitter/tree-sitter/v0.25.10/tree-sitter-macos-x64.gz",
+      "checksum": "C7A962BDC850DCCB184AFDB73853754767304D725B545362352D1838C9A18D7E",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tree-sitter/tree-sitter/v0.25.10/tree-sitter-windows-arm64.gz",
+      "checksum": "460B6245A0B0053BAEA1B72ED2768B28A2C1BF4F7380C2CF361A527BD5BB4A46",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tree-sitter/tree-sitter/v0.25.10/tree-sitter-windows-x64.gz",
+      "checksum": "C940B471683B9CD89B9EFBE8697E14B5244CC09D2E2B889D04C9C76EEA1A8DB3",
+      "algorithm": "sha256"
+    },
+    {
       "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.333.3/registry.yaml",
       "checksum": "47DFBBB1D1F6ED6D97E7511DEA14002FC679CA3C59526DD27204083B9779299F",
       "algorithm": "sha256"

--- a/aqua/aqua.yaml
+++ b/aqua/aqua.yaml
@@ -49,3 +49,4 @@ packages:
   - name: Automattic/harper/harper-ls@v0.68.0
   - name: dandavison/delta@0.18.2
   - name: sharkdp/bat@v0.26.0
+  - name: tree-sitter/tree-sitter@v0.25.10

--- a/nvim/after/plugin/treesitter.lua
+++ b/nvim/after/plugin/treesitter.lua
@@ -36,8 +36,7 @@ require("nvim-treesitter.configs").setup({
 		"javascript",
 		"json",
 		"json5",
-		-- TODO(#78): Latex needs the treesitter CLI.
-		-- "latex",
+		"latex",
 		"liquid",
 		"lua",
 		"make",
@@ -60,9 +59,6 @@ require("nvim-treesitter.configs").setup({
 		"yaml",
 	},
 
-	-- TODO(#78): Latex needs the treesitter CLI.
-	ignore_install = { "latex" }, -- List of parsers to ignore installing
-
 	-- Install parsers synchronously (only applied to `ensure_installed`)
 	sync_install = false,
 
@@ -75,8 +71,6 @@ require("nvim-treesitter.configs").setup({
 
 	highlight = {
 		enable = true,
-		-- TODO(#78): Latex needs the treesitter CLI.
-		disable = { "latex" },
 
 		-- Setting this to true will run `:h syntax` and tree-sitter at the same time.
 		-- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).


### PR DESCRIPTION
**Description:**

Add `tree-sitter` as a CLI tool. It's used by the `treesitter.nvim` Neovim plugin.

**Related Issues:**

Fixes #78 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
