### PR TITLE
feat: add gnu-getopt to the PATH

### DIFF
--- a/bash/_bashrc
+++ b/bash/_bashrc
@@ -190,6 +190,17 @@ function _bashrc_main() {
     # Enable homebrew if present
     if [ -x "/opt/homebrew/bin/brew" ]; then
         eval "$(/opt/homebrew/bin/brew shellenv)"
+
+        # Install GNU getopt on the $PATH. This will likely break other stuff on
+        # macOS.
+        # TODO(#524): Remove once bash-argsparse support Homebrew gnu-getopt
+        # See: https://github.com/Anvil/bash-argsparse/issues/17
+        local getopt_path
+        getopt_path=$(/opt/homebrew/bin/brew --prefix gnu-getopt)
+
+        if [ -d "${getopt_path}" ]; then
+            [[ ":$PATH:" != *":${getopt_path}/bin:"* ]] && PATH="${getopt_path}/bin:${PATH}"
+        fi
     fi
 
     # Go


### PR DESCRIPTION
**Description:**

Add the homebrew `gnu-getopt` version of `getopt` to the `$PATH`. This will fix `tmux-sessionizer` but it may break other things on macOS.

**Related Issues:**

Updates #524 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
