### PR TITLE
fix: telescope.nvim: don't include .git directory

### DIFF
--- a/nvim/after/plugin/telescope.lua
+++ b/nvim/after/plugin/telescope.lua
@@ -23,12 +23,19 @@ require("telescope").setup({
 			"--column",
 			"--smart-case",
 			"--hidden", -- search hidden files
+			"--glob=!**/.git/*", -- don't include .git directory
 		},
 	},
 	pickers = {
 		find_files = {
-			hidden = true,
 			theme = "ivy",
+			find_command = {
+				"rg",
+				"--files",
+				"--color=never",
+				"--hidden", -- include hidden files
+				"--glob=!**/.git/*", -- don't include .git directory
+			},
 		},
 		buffers = {
 			hidden = true,


### PR DESCRIPTION
**Description:**

Don't include the `.git` directory is telescope searches. The `.git` directory is included if `--hidden` is specified unless it is added to `.gitignore`.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
