### PR TITLE
fix: update path to scripts

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,27 +1,26 @@
 # Edit this file to introduce tasks to be run by cron.
-# 
+#
 # Each task to run has to be defined through a single line
 # indicating with different fields when the task will be run
 # and what command to run for the task
-# 
+#
 # To define the time you can provide concrete values for
 # minute (m), hour (h), day of month (dom), month (mon),
-# and day of week (dow) or use '*' in these fields (for 'any').# 
+# and day of week (dow) or use '*' in these fields (for 'any').#
 # Notice that tasks will be started based on the cron's system
 # daemon's notion of time and timezones.
-# 
+#
 # Output of the crontab jobs (including errors) is sent through
 # email to the user the crontab file belongs to (unless redirected).
-# 
+#
 # For example, you can run a backup of all your user accounts
 # at 5 a.m every week with:
 # 0 5 * * 1 tar -zcf /var/backups/home.tgz /home/
-# 
+#
 # For more information see the manual pages of crontab(5) and cron(8)
-# 
+#
 # m h  dom mon dow   command
-*/10 * * * * $HOME/bin/update_authorized_keys.sh
-25   6 * * * bash -c 'cd $HOME/src/dotfiles && git pull origin-ro master && git submodule update --init --recursive && make'
+*/10 * * * * ${HOME}/.local/bin/update_authorized_keys.sh
+35   5 * * * ${HOME}/.local/bin/delete_old_downloads.sh
 25   5 * * * docker image prune -a -f --filter "until=48h"
 30   5 * * * docker container prune -f --filter "until=48h"
-35   5 * * * $HOME/bin/delete_old_downloads.sh


### PR DESCRIPTION
**Description:**

Update user `crontab` paths to use the XDG `.local/bin` directory for executing scripts.

**Related Issues:**

Fixes #468 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
