### PR TITLE
feat: add rootMarkers for markdownlint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ lua-format: $(AQUA_ROOT_DIR)/.installed ## Format Lua files.
 	if [ "$${files}" == "" ]; then \
 		exit 0; \
 	fi; \
-	stylua --config-path stylua.toml $${files}
+	stylua $${files}
 
 .PHONY: md-format
 md-format: node_modules/.installed ## Format Markdown files.

--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -114,8 +114,7 @@ local todos = {
 -- {{{ Info-level todos (NOTE, INFO, PERF, OPTIMIZE, TEST)
 local todos_note = {
 	prefix = "todos",
-	lintCommand =
-	"todos --todo-types NOTE,Note,note,INFO,Info,info,PERF,Perf,perf,OPTIM,Optim,optim,OPTIMIZE,Optimize,optimize,TEST,Test,test",
+	lintCommand = "todos --todo-types NOTE,Note,note,INFO,Info,info,PERF,Perf,perf,OPTIM,Optim,optim,OPTIMIZE,Optimize,optimize,TEST,Test,test",
 	lintStdin = false,
 	lintIgnoreExitCode = true,
 	lintSeverity = 3, -- 3 = info
@@ -223,11 +222,12 @@ lspconfig.harper_ls.setup({})
 
 -- lua_ls {{{
 lspconfig.lua_ls.setup({
-	format = {
-		-- Disable CppCXY/EmmyLuaCodeStyle in favor of stylua via
+	on_attach = function(client)
+		-- Disable the documentFormattingProvider for lua-ls
+		-- This disable CppCXY/EmmyLuaCodeStyle in favor of stylua via
 		-- efm-langserver.
-		enable = false,
-	},
+		client.server_capabilities.documentFormattingProvider = false
+	end,
 	on_init = function(client)
 		if client.workspace_folders then
 			local path = client.workspace_folders[1].name


### PR DESCRIPTION
**Description:**

Add `rootMarkers` to the `markdownlint` configuration for `efm-langserver`. This mirrors how the `markdownlint` extension works for VSCode. The CLI itself doesn't have support for automatically loading configuration in subdirectories.

**Related Issues:**

Related to #558 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
