### PR TITLE
fix: check for tmux in tmux utilities

### DIFF
--- a/bash/_bashrc
+++ b/bash/_bashrc
@@ -28,28 +28,21 @@ function _bashrc_main() {
         source "${HOME}/.bashrc_init_local"
     fi
 
-    # tmux/screen
-    # Start a tmux or screen session if not already in one
-    # Exit directly after the tmux/screen session is exited
+    # tmux
+    # Start a tmux session if not already in one
+    # Exit directly after the tmux session is exited
     # Only run if logged in remotely via ssh
-    local tmux_cmd=tmux
-    if command -v tmx2 >/dev/null 2>&1; then
-        tmux_cmd=tmx2
-    fi
     if shopt -q login_shell && [ -n "${SSH_CLIENT}" ]; then
         # Only run if running in a terminal.
         if [[ (-t 1) && (${TERM} != screen*) && -z ${TMUX} ]]; then
-            if command -v "${tmux_cmd}" >/dev/null 2>&1; then
+            if command -v tmux >/dev/null 2>&1; then
                 # Attempt to discover a detached session
                 # Use the current username as the session name.
-                if "${tmux_cmd}" has-session -t "${USER}" 2>/dev/null; then
-                    exec "${tmux_cmd}" attach-session -t "${USER}"
+                if tmux has-session -t "${USER}" 2>/dev/null; then
+                    exec tmux attach-session -t "${USER}"
                 else
-                    exec "${tmux_cmd}" new-session -s "${USER}"
+                    exec tmux new-session -s "${USER}"
                 fi
-            elif command -v screen >/dev/null 2>&1; then
-                # Attempt to discover a detached session
-                exec screen -q -RR
             fi
         else
             # If in a tmux/screen session print the motd.

--- a/bin/all/project-windowizer
+++ b/bin/all/project-windowizer
@@ -42,6 +42,11 @@ function _main() {
     # Command line parsing is done here.
     argsparse_parse_options "$@"
 
+    if ! command -v tmux >/dev/null 2>&1; then
+        echo "${0}: ERROR: this script requires tmux." >&2
+        exit 1
+    fi
+
     if [[ -z ${TMUX+x} ]]; then
         echo "${0}: ERROR: this script requires tmux to be running." >&2
         exit 1

--- a/bin/all/tmux-sessionizer
+++ b/bin/all/tmux-sessionizer
@@ -59,6 +59,11 @@ function _main() {
     # Command line parsing is done here.
     argsparse_parse_options "$@"
 
+    if ! command -v tmux >/dev/null 2>&1; then
+        echo "${0}: ERROR: this script requires tmux." >&2
+        exit 1
+    fi
+
     local query=${program_params[0]:-""}
 
     local selected
@@ -76,14 +81,14 @@ function _main() {
     fi
 
     selected_name=$(basename "$selected" | tr . _)
-    tmux_running=$(pgrep tmux)
+    tmux_running=$(pgrep tmux || true)
 
     # Session name can't be a number so add a trailing underscore.
     if [[ ${selected_name} =~ ^[0-9]+$ ]]; then
         selected_name="${selected_name}_"
     fi
 
-    if [[ -z $TMUX ]] && [[ -z ${tmux_running} ]]; then
+    if [[ -z ${TMUX+x} ]] && [[ -z ${tmux_running} ]]; then
         tmux new-session -s "${selected_name}" -c "${selected}"
         # NOTE: new-session opens the first window.
         for ((i = 2; i <= program_options['windows']; i++)); do


### PR DESCRIPTION
**Description:**

Check for the `tmux` command and an appropriate session in `tmux-sessionizer` and `project-windowizer`.

Remove support for the Google-specific `tmx2` command.

**Related Issues:**

Fixes #545 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
