### PR TITLE
feat: add bash completion

### DIFF
--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -1626,6 +1626,31 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/jqlang/jq/jq-1.8.1/jq-linux-amd64",
+      "checksum": "020468DE7539CE70EF1BCEAF7CDE2E8C4F2CA6C3AFB84642AABC5C97D9FC2A0D",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/jqlang/jq/jq-1.8.1/jq-linux-arm64",
+      "checksum": "6BC62F25981328EDD3CFCFE6FE51B073F2D7E7710D7EF7FCDAC28D4E384FC3D4",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/jqlang/jq/jq-1.8.1/jq-macos-amd64",
+      "checksum": "E80DBE0D2A2597E3C11C404F03337B981D74B4A8504B70586C354B7697A7C27F",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/jqlang/jq/jq-1.8.1/jq-macos-arm64",
+      "checksum": "A9FE3EA2F86DFC72F6728417521EC9067B343277152B114F4E98D8CB0E263603",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/jqlang/jq/jq-1.8.1/jq-windows-amd64.exe",
+      "checksum": "23CB60A1354EED6BCC8D9B9735E8C7B388CD1FDCB75726B93BC299EF22DD9334",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/junegunn/fzf/v0.61.1/fzf-0.61.1-darwin_amd64.tar.gz",
       "checksum": "1BFEAD33F9401D6DDF4D6128C5A5F55266209557FBC1D9FD41B0ABF78DF1752B",
       "algorithm": "sha256"

--- a/aqua/aqua.yaml
+++ b/aqua/aqua.yaml
@@ -59,3 +59,4 @@ packages:
   - name: checkmake/checkmake@0.2.2
   - name: mikefarah/yq@v4.48.1
   - name: sxyazi/yazi@v25.5.31
+  - name: jqlang/jq@jq-1.8.1

--- a/bash/_bash_completion
+++ b/bash/_bash_completion
@@ -23,12 +23,6 @@ function _bash_completion() {
         eval "$(python -m pip completion --bash --no-python-version-warning)"
     fi
 
-    # kubectl bash completion
-    if command -v kubectl >/dev/null 2>&1; then
-        # shellcheck source=/dev/null
-        source <(kubectl completion bash)
-    fi
-
     # Aqua completion
     if command -v aqua >/dev/null 2>&1; then
         # shellcheck source=/dev/null
@@ -47,10 +41,22 @@ function _bash_completion() {
         source <(cosign completion bash)
     fi
 
+    # delta completion
+    if command -v delta >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        source <(delta --generate-completion bash)
+    fi
+
     # fx completion
     if command -v fx >/dev/null 2>&1; then
         # shellcheck source=/dev/null
         source <(fx --comp bash)
+    fi
+
+    # fzf completion
+    if command -v fzf >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        source <(fzf --bash)
     fi
 
     # GitHub CLI completion
@@ -59,16 +65,58 @@ function _bash_completion() {
         source <(gh completion --shell bash)
     fi
 
+    # helm bash completion
+    if command -v helm >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        source <(helm completion bash)
+    fi
+
+    # kind bash completion
+    if command -v kind >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        source <(kind completion bash)
+    fi
+
+    # kubeadm bash completion
+    if command -v kubeadm >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        source <(kubeadm completion bash)
+    fi
+
+    # kubectl bash completion
+    if command -v kubectl >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        source <(kubectl completion bash)
+    fi
+
+    # kustomize bash completion
+    if command -v kustomize >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        source <(kustomize completion bash)
+    fi
+
     # npm completion
     if command -v npm >/dev/null 2>&1; then
         # shellcheck source=/dev/null
         source <(npm completion bash)
     fi
 
+    # ripgrep completion
+    if command -v rg >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        source <(rg --generate=complete-bash)
+    fi
+
     # slsa-verifier completion
     if command -v slsa-verifier >/dev/null 2>&1; then
         # shellcheck source=/dev/null
         source <(slsa-verifier completion bash)
+    fi
+
+    # tree-sitter completion
+    if command -v tree-sitter >/dev/null 2>&1; then
+        # shellcheck source=/dev/null
+        source <(tree-sitter complete --shell bash)
     fi
 
     # yq completion


### PR DESCRIPTION
**Description:**

Add bash completion for various programs:
- delta
- fzf
- helm
- kind
- kubeadm
- kubectl
- kustomize
- ripgrep
- tree-sitter

Also install 'jq' via Aqua.

**Related Issues:**

Fixes #572 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
