### PR TITLE
feat: add 'tw' alias for creating temporary workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## `2025-11-29`
+
+- Bash: Add a new `tw` alias for creating temporary workspace directories under
+  `${HOME}/.tmp/workspace/`
+  ([#577](https://github.com/ianlewis/dotfiles/issues/577)).
+
 ## `2025-11-28`
 
 - `cron`: Add support for loading user-specific `crontab` files in the

--- a/bash/_bash_aliases
+++ b/bash/_bash_aliases
@@ -48,6 +48,9 @@ function _bash_aliases() {
     # Create a new dev session.
     alias ns='tmux-sessionizer'
 
+    # Create a new temporary workspace.
+    alias tw='mkdir -p "${HOME}/.tmp/workspace" && tmux-sessionizer --new --mindepth 1 --dir "${HOME}/.tmp/workspace"'
+
     # Split window and start nvim.
     alias pw='project-windowizer'
 

--- a/bin/all/delete_old_downloads.sh
+++ b/bin/all/delete_old_downloads.sh
@@ -27,12 +27,12 @@ function _main() {
     local days
 
     # Explicitly specify the directories for safety.
-    dirs="$HOME/tmp/ $HOME/Downloads/"
+    dirs="${HOME}/.tmp/ ${HOME}/Downloads/"
 
     days=${1:-""}
 
     if [ "${days}" = "" ]; then
-        days=14
+        days=28
     fi
 
     for d in ${dirs}; do

--- a/bin/all/tmux-sessionizer
+++ b/bin/all/tmux-sessionizer
@@ -51,6 +51,7 @@ function _main() {
     # Project directories are GitHub style <user>/<repo> thus default depth of 2.
     argsparse_use_option "mindepth" "Minimum directory search depth." "value" "default:2" "short:m" "type:uint"
     argsparse_use_option "maxdepth" "Maximum directory search depth." "value" "default:2" "short:x" "type:uint"
+    argsparse_use_option "new" "Create a new folder if no selection." "short:n"
 
     # Query is is a single optional parameter.
     argsparse_describe_parameters "QUERY?"
@@ -65,27 +66,71 @@ function _main() {
     argsparse_parse_options "$@"
 
     if ! command -v tmux >/dev/null 2>&1; then
-        echo "${0}: ERROR: this script requires tmux." >&2
+        echo "${0}: tmux is required." >&2
+        return 1
+    fi
+
+    if [ ! -d "${program_options['dir']}" ]; then
+        echo "${0}: '${program_options['dir']}' does not exist or is not a directory." >&2
         return 1
     fi
 
     local query=${program_params[0]:-""}
 
+    local base_dir
+    local lines
     local selected
     local selected_name
     local tmux_running
+    local select_option=""
 
-    selected=$(find \
-        "${program_options['dir']}" \
+    # Remove trailing slashes for consistency.
+    base_dir="${program_options['dir']%%+(/)}"
+
+    # If a query is provided, select the only match automatically (if it's the
+    # only match). An empty query should always result in a list of options.
+    if [[ -n ${query} ]]; then
+        select_option="--select-1"
+    fi
+
+    # Read the all lines from fzf.
+    # NOTE: fzf --print-query always prints the query as the first line. If
+    #       there is a selection, it will be on the second line.
+    IFS=$'\n' readarray -t lines <<<"$(find \
+        "${base_dir}" \
         -mindepth "${program_options['mindepth']}" \
         -maxdepth "${program_options['maxdepth']}" \
-        -type d | fzf --query="${query}" --select-1)
+        -type d | fzf --query="${query}" --print-query ${select_option})"
+
+    if [[ ${#lines[@]} -eq 0 ]]; then
+        return 0
+    elif [[ ${#lines[@]} -eq 1 ]]; then
+        if ! argsparse_is_option_set "new"; then
+            return 0
+        fi
+
+        # New folder.
+        new_folder="${lines[0]}"
+        if [[ -z ${new_folder} ]]; then
+            return 0
+        fi
+
+        selected="${base_dir}/${new_folder}"
+        mkdir -p "${selected}"
+    elif [[ ${#lines[@]} -ge 2 ]]; then
+        # NOTE: First line is the query.
+        selected="${lines[1]}"
+    fi
 
     if [[ -z ${selected} ]]; then
         return 0
     fi
 
-    selected_name=$(basename "$selected" | tr . _)
+    # Remove the base directory prefix and convert dots to underscores for tmux
+    # session name.
+    selected_name="${selected#"${base_dir}"}"
+    selected_name=$(echo "${selected_name##+(/)}" | tr . _)
+
     tmux_running=$(pgrep tmux || true)
 
     # Session name can't be a number so add a trailing underscore.


### PR DESCRIPTION
**Description:**

Add a `tw` alias that allows for creating temporary workspaces under `$HOME/.tmp/workspace`. The alias makes use of `tmux-sessionizer`. To allow for creating new workspace directories, a `--new` option was added to `tmux-sessionizer`.

`delete_old_download.sh` was updated to target `$HOME/.tmp`. The default max age of files is now 28 days; up from 14 days to allow for longer lived temporary workspaces.

**Related Issues:**

Fixes #577 
Fixes #467 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
