### PR TITLE
feat: enable OSC 52 in Ghostty

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -61,3 +61,7 @@
 font-feature = -calt
 font-feature = -liga
 font-feature = -dlig
+
+# Allow terminal applications to access the clipboard (OSC 52).
+clipboard-read = allow
+clipboard-write = allow


### PR DESCRIPTION
**Description:**

Enable OSC 52 in Ghostty.
https://ghostty.org/docs/config/reference#clipboard-read

**Related Issues:**

Updates #604 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
