### PR TITLE
chore: add crictl.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ all: test install ## Run all tests, install and configure everything.
 install: install-tools install-runtimes configure ## Install and configure everything.
 
 .PHONY: configure
-configure: configure-aqua configure-bash configure-bat configure-crontab configure-efm-langserver configure-ghostty configure-git configure-nix configure-node configure-nvim configure-tmux
+configure: configure-aqua configure-bash configure-bat configure-crictl configure-crontab configure-efm-langserver configure-ghostty configure-git configure-nix configure-node configure-nvim configure-tmux
 
 .PHONY: install-tools
 install-tools: install-bin install-slsa-verifier install-aqua
@@ -831,6 +831,12 @@ configure-bat: $(XDG_CONFIG_HOME)/.created install-aqua ## Configure bat.
 		$(REPO_ROOT)/nvim/pack/nvim/start/tokyonight.nvim/extras/sublime/tokyonight_moon.tmTheme \
 		"$$($${aqua_dir}/bin/bat --config-dir)/themes/tokyonight_moon.tmTheme"; \
 	"$${aqua_dir}/bin/bat" cache --build
+
+.PHONY: configure-crictl
+configure-crictl: $(XDG_CONFIG_HOME)/.created ## Configure crictl.
+	@# bash \
+	mkdir -p $(XDG_CONFIG_HOME)/crictl; \
+	ln -sf $(REPO_ROOT)/crictl/crictl.yaml $(XDG_CONFIG_HOME)/crictl/crictl.yaml
 
 .PHONY: configure-crontab
 configure-crontab: install-bin ## Configure crontab.

--- a/bash/_bashrc
+++ b/bash/_bashrc
@@ -203,8 +203,14 @@ function _bashrc_source_local() {
 }
 
 function _bashrc_main() {
+    XDG_CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
+    export XDG_CACHE_HOME
+    XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/.config}"
+    export XDG_CONFIG_HOME
     XDG_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"
     export XDG_DATA_HOME
+    XDG_STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"
+    export XDG_STATE_HOME
 
     if [[ -r "${HOME}/.bashrc_init_local" ]]; then
         # shellcheck source=/dev/null
@@ -299,8 +305,8 @@ function _bashrc_main() {
     # Set the bat theme.
     export BAT_THEME="tokyonight_moon"
 
-    local bash_lib_dir="${HOME}/.local/share/bash/lib"
-    local nvim_plugin_dir="${HOME}/.config/nvim/pack/nvim/start"
+    local bash_lib_dir="${XDG_DATA_HOME}/bash/lib"
+    local nvim_plugin_dir="${XDG_CONFIG_HOME}/nvim/pack/nvim/start"
 
     # Simple Bash Prompt
     # shellcheck source=/dev/null
@@ -335,6 +341,12 @@ function _bashrc_main() {
         source "${bash_lib_dir}/ssh-find-agent/ssh-find-agent.sh"
 
         ssh_find_agent -a || eval "$(ssh-agent -s)" >/dev/null
+    fi
+
+    # Set a default crictl config path to squelch warnings but defer to the
+    # system wide config if it exists.
+    if [[ ! -r "/etc/crictl.yaml" ]]; then
+        export CRI_CONFIG_FILE="${XDG_CONFIG_HOME}/crictl/crictl.yaml"
     fi
 
     # Update the PATH

--- a/bash/test/e2e/crictl.bats
+++ b/bash/test/e2e/crictl.bats
@@ -1,0 +1,26 @@
+# Copyright 2025 Ian Lewis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup() {
+    E2E_HOME="${E2E_HOME:-${HOME}}"
+    BASE_PATH="$(cd "$(dirname "$(dirname "$(dirname "$(dirname "${BATS_TEST_FILENAME}")")")")" >/dev/null 2>&1 && pwd)"
+
+    load "${BASE_PATH}/bash/test/test_helper/bats-support/load"
+    load "${BASE_PATH}/bash/test/test_helper/bats-assert/load"
+    load "${BASE_PATH}/bash/test/test_helper/bats-file/load"
+}
+
+@test "crictl.yaml is linked correctly" {
+    assert_symlink_to "${BASE_PATH}/crictl/crictl.yaml" "${E2E_HOME}/.config/crictl/crictl.yaml"
+}

--- a/crictl/crictl.yaml
+++ b/crictl/crictl.yaml
@@ -1,0 +1,17 @@
+# Copyright 2025 Ian Lewis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is deliberately left blank to disable crictl configuration. Options
+# should be specified on the command line or via environment variables since
+# they are machine specific.


### PR DESCRIPTION
**Description:**

Add a blank `crictl.yaml` to squelch warnings about `/etc/crictl.yaml` not existing.

**Related Issues:**

Fixes #605 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
