### PR TITLE
fix: downgrade tree-sitter CLI

### DIFF
--- a/aqua/aqua.yaml
+++ b/aqua/aqua.yaml
@@ -49,7 +49,8 @@ packages:
   - name: dandavison/delta@0.18.2
   - name: sharkdp/bat@v0.26.1
   - name: sharkdp/fd@v10.3.0
-  - name: tree-sitter/tree-sitter@v0.26.3
+  # TODO(#655): Update to v0.26.0+ after dev server issue is resolved
+  - name: tree-sitter/tree-sitter@v0.25.10
   - name: kubernetes/kubernetes/kubectl@v1.34.2
   - name: kubernetes/kubernetes/kubeadm@v1.34.2
   - name: kubernetes-sigs/kind@v0.31.0


### PR DESCRIPTION
**Description:**

Downgrade tree-sitter CLI to avoid issues with old versions of glibc.

**Related Issues:**

Updates #655 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
