### PR TITLE
feat: add auth check to clone command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -772,7 +772,7 @@ zizmor: .venv/.installed ## Runs the zizmor linter.
 .PHONY: install-bin
 install-bin: $(XDG_BIN_HOME)/.created $(XDG_CONFIG_HOME)/.created ## Install binary scripts.
 	@# bash \
-	ln -sf $(REPO_ROOT)/bin/all/clone $(XDG_BIN_HOME)/clone; \
+	ln -sf $(REPO_ROOT)/bin/all/clone.bash $(XDG_BIN_HOME)/clone; \
 	ln -sf $(REPO_ROOT)/bin/all/delete_old_downloads.sh $(XDG_BIN_HOME)/delete_old_downloads.sh; \
 	ln -sf $(REPO_ROOT)/bin/all/docker_prune.sh $(XDG_BIN_HOME)/docker_prune.sh; \
 	ln -sf $(REPO_ROOT)/bin/all/project-windowizer $(XDG_BIN_HOME)/project-windowizer; \

--- a/bash/test/e2e/bin.bats
+++ b/bash/test/e2e/bin.bats
@@ -41,7 +41,7 @@ setup() {
     assert_symlink_to "${BASE_PATH}/bin/all/delete_old_downloads.sh" "${E2E_HOME}/.local/bin/delete_old_downloads.sh"
     assert_symlink_to "${BASE_PATH}/bin/all/docker_prune.sh" "${E2E_HOME}/.local/bin/docker_prune.sh"
     assert_symlink_to "${BASE_PATH}/bin/all/update_authorized_keys.sh" "${E2E_HOME}/.local/bin/update_authorized_keys.sh"
-    assert_symlink_to "${BASE_PATH}/bin/all/clone" "${E2E_HOME}/.local/bin/clone"
+    assert_symlink_to "${BASE_PATH}/bin/all/clone.bash" "${E2E_HOME}/.local/bin/clone"
     assert_symlink_to "${BASE_PATH}/bin/all/tmux-sessionizer" "${E2E_HOME}/.local/bin/tmux-sessionizer"
     assert_symlink_to "${BASE_PATH}/bin/all/project-windowizer" "${E2E_HOME}/.local/bin/project-windowizer"
     assert_symlink_to "${BASE_PATH}/bin/all/withpass.sh" "${E2E_HOME}/.local/bin/withpass"

--- a/bin/all/clone.bash
+++ b/bin/all/clone.bash
@@ -94,15 +94,28 @@ function _clone() {
         "${create_command[@]}"
     fi
 
-    # Clone the repository.
+    # Check that the GitHub CLI is installed.
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "$(basename "${0}"): ERROR: GitHub CLI is not installed." >&2
+        exit 1
+    fi
 
+    # Check if the user is authenticated with GitHub CLI.
+    # NOTE: If not authenticated gh repo clone might check out the repository
+    # using HTTPS which would make you unable to push.
+    if ! gh auth status >/dev/null 2>&1; then
+        echo "$(basename "${0}"): ERROR: You are not logged into any GitHub hosts. To log in, set the GH_TOKEN environment variable or run: gh auth login." >&2
+        exit 1
+    fi
+
+    # Clone the repository.
     owner=$(gh repo view "${repo_id}" --json owner | jq -r '.owner.login')
     repo_name=$(gh repo view "${repo_id}" --json name | jq -r '.name')
 
     dest="${program_options['dir']}/${owner}/${repo_name}"
 
     if [ -e "${dest}" ]; then
-        echo "${0}: ERROR: ${dest} already exists." >&2
+        echo "$(basename "${0}"): ERROR: ${dest} already exists." >&2
         exit 1
     fi
 


### PR DESCRIPTION
**Description:**

Add an authentication check to the `clone` command. Also add the `.bash` extension in the repo to indicate its file type.

**Related Issues:**

Fixes #584 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
