### PR TITLE
feat: use XDG_STATE_DIR for efm-langserver log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -869,10 +869,15 @@ configure-crontab: install-bin ## Configure crontab.
 $(XDG_CONFIG_HOME)/efm-langserver/config.yaml: efm-langserver/config.yaml $(XDG_CONFIG_HOME)/.created
 	@# bash \
 	mkdir -p $(XDG_CONFIG_HOME)/efm-langserver; \
-	sed 's|$${XDG_CONFIG_HOME}|'$(XDG_CONFIG_HOME)'|'< $< > $@
+	sed 's|$${XDG_STATE_HOME}|'$(XDG_STATE_HOME)'|'< $< > $@
+
+$(XDG_STATE_HOME)/efm-langserver/.created:
+	@# bash \
+	mkdir -p $(XDG_STATE_HOME)/efm-langserver; \
+	touch $@
 
 .PHONY: configure-efm-langserver
-configure-efm-langserver: $(XDG_CONFIG_HOME)/efm-langserver/config.yaml ## Configure efm-langserver.
+configure-efm-langserver: $(XDG_CONFIG_HOME)/efm-langserver/config.yaml $(XDG_STATE_HOME)/efm-langserver/.created ## Configure efm-langserver.
 
 .PHONY: configure-git
 configure-git: ## Configure git.

--- a/efm-langserver/config.yaml
+++ b/efm-langserver/config.yaml
@@ -20,5 +20,5 @@ version: 2
 # NOTE: efm-langserver does not support substitutions in the configuration
 # file. Substitutions like ${XDG_CONFIG_HOME} are made by the Makefile upon
 # installation.
-log-file: ${XDG_CONFIG_HOME}/efm-langserver/efm-langserver.log
+log-file: ${XDG_STATE_HOME}/efm-langserver/efm-langserver.log
 log-level: 1


### PR DESCRIPTION
**Description:**

Save the `efm-langserver.log` to the `$XDG_STATE_HOME` directory.

**Related Issues:**

- #739 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
