### PR TITLE
feat: update temporary workspace directory

### DIFF
--- a/bash/_bash_aliases
+++ b/bash/_bash_aliases
@@ -51,7 +51,7 @@ function _bash_aliases() {
     alias ns='tmux-sessionizer'
 
     # Create a new temporary workspace.
-    alias tw='mkdir -p "${HOME}/tmp/workspace" && tmux-sessionizer --new --mindepth 1 --dir "${HOME}/tmp/workspace"'
+    alias tw='tmux-sessionizer --new --mindepth 1 --dir "$(_bashrc_temp_workspace_dir)"'
 
     # Split window and start nvim.
     alias pw='project-windowizer'

--- a/bash/_bashrc
+++ b/bash/_bashrc
@@ -225,8 +225,8 @@ function _bashrc_source_local() {
 function _bashrc_user_temp() {
     # if /var/tmp exists use it so that workspaces can persist across reboots.
     local tmp_dir="/var/tmp"
-    if [[ ! -d "${tmp_dir}" ]] || [[ ! -w "${tmp_dir}" ]]; then
-        if [[ -n "${TMPDIR:-}" ]] && [[ -d "${TMPDIR}" ]] && [[ -w "${TMPDIR}" ]]; then
+    if [[ ! -d ${tmp_dir} ]] || [[ ! -w ${tmp_dir} ]]; then
+        if [[ -n ${TMPDIR:-} ]] && [[ -d ${TMPDIR} ]] && [[ -w ${TMPDIR} ]]; then
             tmp_dir="${TMPDIR}"
         else
             # Otherwise, use the default /tmp directory.
@@ -235,7 +235,7 @@ function _bashrc_user_temp() {
     fi
 
     local ws_root="${tmp_dir}/dotfiles-user-tmp-${UID}"
-    if [[ ! -d "${ws_root}" ]]; then
+    if [[ ! -d ${ws_root} ]]; then
         mkdir -m 0700 "${ws_root}"
     fi
 
@@ -246,7 +246,7 @@ function _bashrc_user_temp() {
     local stat_group_id
     local stat_permissions
     read -r stat_user_id stat_group_id stat_permissions <<<"$(stat -c "%u %g %a" "${ws_root}")"
-    if [[ "${stat_user_id}" != "${UID}" ]] || [[ "${stat_group_id}" != "${GID}" ]] || [[ "${stat_permissions}" != "700" ]]; then
+    if [[ ${stat_user_id} != "${UID}" ]] || [[ ${stat_group_id} != "${GID}" ]] || [[ ${stat_permissions} != "700" ]]; then
         echo "WARN: Workspace directory ${ws_root} has incorrect ownership or permissions." >&2
         ws_root="$(mktemp -d -t "dotfiles-user-tmp-XXXXXXXXXX")"
     fi
@@ -255,10 +255,10 @@ function _bashrc_user_temp() {
     # to pick up the user's configuration (e.g. aqua, nodenv, etc.)
 
     local user_tmp="${HOME}/.tmp"
-    if [[ -L "${user_tmp}" ]]; then
+    if [[ -L ${user_tmp} ]]; then
         local canon_user_tmp
         canon_user_tmp="$(readlink -f "${user_tmp}")"
-        if [[ "${canon_user_tmp}" != "${ws_root}" ]]; then
+        if [[ ${canon_user_tmp} != "${ws_root}" ]]; then
             echo "WARN: ${user_tmp} is a symlink to ${canon_user_tmp} instead of ${ws_root}. Updating the symlink." >&2
             rm -f "${user_tmp}"
             ln -sf "${ws_root}" "${user_tmp}"
@@ -279,7 +279,7 @@ function _bashrc_user_temp() {
 function _bashrc_temp_workspace_dir() {
     local ws_dir
     ws_dir="$(_bashrc_user_temp)/workspace"
-    if [[ ! -d "${ws_dir}" ]]; then
+    if [[ ! -d ${ws_dir} ]]; then
         mkdir -m 0700 "${ws_dir}"
     fi
 

--- a/bash/_bashrc
+++ b/bash/_bashrc
@@ -217,6 +217,39 @@ function _bashrc_source_local() {
     fi
 }
 
+# _bashrc_get_temp_workspace_dir returns a directory path for temporary
+# workspaces. It prefers /var/tmp if it exists and is writable, otherwise it
+# falls back to /tmp. The workspace directory is named "user-ws-UID" where UID
+# is the user's ID. If the workspace directory does not exist, it is created
+# with permissions 0700.
+function _bashrc_temp_workspace_dir() {
+    # if /var/tmp exists use it so that workspaces can persist across reboots.
+    local tmp_dir="/var/tmp"
+    if [[ ! -d "${tmp_dir}" ]] || [[ ! -w "${tmp_dir}" ]]; then
+        if [[ -z "${TMPDIR:-}" ]] && [[ -d "${TMPDIR}" ]] && [[ -d "${TMPDIR}" ]]; then
+            tmp_dir="${TMPDIR}"
+        else
+            # Otherwise, use the default /tmp directory.
+            tmp_dir="/tmp"
+        fi
+    fi
+
+    local ws_root="${tmp_dir}/user-tw-${UID}"
+    if [[ ! -d "${ws_root}" ]]; then
+        mkdir -m 0700 "${ws_root}"
+    fi
+    # Link to the temporary directory from the user's home directory. We do this
+    # to pick up the user's configuration (e.g. aqua, nodenv, etc.)
+    # NOTE: We assume $HOME exists so it's ok that `-m` only applies to the last
+    #       directory in the path.
+    # shellcheck disable=SC2174
+    mkdir -p -m 0700 "${HOME}/.tmp"
+    rm -f "${HOME}/.tmp/workspace"
+    ln -sf "${ws_root}" "${HOME}/.tmp/workspace"
+
+    echo "${HOME}/.tmp/workspace"
+}
+
 function _bashrc_main() {
     XDG_CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
     export XDG_CACHE_HOME

--- a/bash/_bashrc
+++ b/bash/_bashrc
@@ -217,12 +217,12 @@ function _bashrc_source_local() {
     fi
 }
 
-# _bashrc_get_temp_workspace_dir returns a directory path for temporary
-# workspaces. It prefers /var/tmp if it exists and is writable, otherwise it
-# falls back to /tmp. The workspace directory is named "user-ws-UID" where UID
-# is the user's ID. If the workspace directory does not exist, it is created
-# with permissions 0700.
-function _bashrc_temp_workspace_dir() {
+# _bashrc_user_temp returns a directory path for temporary workspaces. It
+# prefers /var/tmp if it exists and is writable, otherwise it falls back to
+# /tmp. The workspace directory is named "user-ws-UID" where UID is the user's
+# ID. If the workspace directory does not exist, it is created with permissions
+# 0700.
+function _bashrc_user_temp() {
     # if /var/tmp exists use it so that workspaces can persist across reboots.
     local tmp_dir="/var/tmp"
     if [[ ! -d "${tmp_dir}" ]] || [[ ! -w "${tmp_dir}" ]]; then
@@ -234,20 +234,35 @@ function _bashrc_temp_workspace_dir() {
         fi
     fi
 
-    local ws_root="${tmp_dir}/user-tw-${UID}"
+    local ws_root="${tmp_dir}/dotfiles-user-tmp-${UID}"
     if [[ ! -d "${ws_root}" ]]; then
         mkdir -m 0700 "${ws_root}"
     fi
+
     # Link to the temporary directory from the user's home directory. We do this
     # to pick up the user's configuration (e.g. aqua, nodenv, etc.)
     # NOTE: We assume $HOME exists so it's ok that `-m` only applies to the last
     #       directory in the path.
     # shellcheck disable=SC2174
-    mkdir -p -m 0700 "${HOME}/.tmp"
-    rm -f "${HOME}/.tmp/workspace"
-    ln -sf "${ws_root}" "${HOME}/.tmp/workspace"
+    rm -f "${HOME}/.tmp"
+    ln -sf "${ws_root}" "${HOME}/.tmp"
 
-    echo "${HOME}/.tmp/workspace"
+    echo "${HOME}/.tmp"
+}
+
+# _bashrc_temp_workspace_dir returns a directory path for temporary workspaces.
+# It is used by the 'tw' alias to create temporary workspaces for development.
+# It is a "workspace" subdirectory under the user temp directory returned by
+# _bashrc_user_temp. If the workspace directory does not exist, it is created
+# with permissions 0700.
+function _bashrc_temp_workspace_dir() {
+    local ws_dir
+    ws_dir="$(_bashrc_user_temp)/workspace"
+    if [[ ! -d "${ws_dir}" ]]; then
+        mkdir -m 0700 "${ws_dir}"
+    fi
+
+    echo "${ws_dir}"
 }
 
 function _bashrc_main() {

--- a/bash/_bashrc
+++ b/bash/_bashrc
@@ -219,14 +219,14 @@ function _bashrc_source_local() {
 
 # _bashrc_user_temp returns a directory path for temporary workspaces. It
 # prefers /var/tmp if it exists and is writable, otherwise it falls back to
-# /tmp. The workspace directory is named "user-ws-UID" where UID is the user's
-# ID. If the workspace directory does not exist, it is created with permissions
-# 0700.
+# /tmp. The workspace directory is named "dotfiles-user-tmp-UID" where UID is
+# the user's ID. If the workspace directory does not exist, it is created with
+# permissions 0700.
 function _bashrc_user_temp() {
     # if /var/tmp exists use it so that workspaces can persist across reboots.
     local tmp_dir="/var/tmp"
     if [[ ! -d "${tmp_dir}" ]] || [[ ! -w "${tmp_dir}" ]]; then
-        if [[ -z "${TMPDIR:-}" ]] && [[ -d "${TMPDIR}" ]] && [[ -d "${TMPDIR}" ]]; then
+        if [[ -n "${TMPDIR:-}" ]] && [[ -d "${TMPDIR}" ]] && [[ -w "${TMPDIR}" ]]; then
             tmp_dir="${TMPDIR}"
         else
             # Otherwise, use the default /tmp directory.
@@ -239,15 +239,36 @@ function _bashrc_user_temp() {
         mkdir -m 0700 "${ws_root}"
     fi
 
+    # test that the owner, group, and permissions of the workspace directory is
+    # correct. If not, print a warning and fall back to using a new temporary
+    # directory.
+    local stat_user_id
+    local stat_group_id
+    local stat_permissions
+    read -r stat_user_id stat_group_id stat_permissions <<<"$(stat -c "%u %g %a" "${ws_root}")"
+    if [[ "${stat_user_id}" != "${UID}" ]] || [[ "${stat_group_id}" != "${GID}" ]] || [[ "${stat_permissions}" != "700" ]]; then
+        echo "WARN: Workspace directory ${ws_root} has incorrect ownership or permissions." >&2
+        ws_root="$(mktemp -d -t "dotfiles-user-tmp-XXXXXXXXXX")"
+    fi
+
     # Link to the temporary directory from the user's home directory. We do this
     # to pick up the user's configuration (e.g. aqua, nodenv, etc.)
-    # NOTE: We assume $HOME exists so it's ok that `-m` only applies to the last
-    #       directory in the path.
-    # shellcheck disable=SC2174
-    rm -f "${HOME}/.tmp"
-    ln -sf "${ws_root}" "${HOME}/.tmp"
 
-    echo "${HOME}/.tmp"
+    local user_tmp="${HOME}/.tmp"
+    if [[ -L "${user_tmp}" ]]; then
+        local canon_user_tmp
+        canon_user_tmp="$(readlink -f "${user_tmp}")"
+        if [[ "${canon_user_tmp}" != "${ws_root}" ]]; then
+            echo "WARN: ${user_tmp} is a symlink to ${canon_user_tmp} instead of ${ws_root}. Updating the symlink." >&2
+            rm -f "${user_tmp}"
+            ln -sf "${ws_root}" "${user_tmp}"
+        fi
+    else
+        rm -rf "${user_tmp}"
+        ln -sf "${ws_root}" "${user_tmp}"
+    fi
+
+    echo "${user_tmp}"
 }
 
 # _bashrc_temp_workspace_dir returns a directory path for temporary workspaces.
@@ -266,6 +287,10 @@ function _bashrc_temp_workspace_dir() {
 }
 
 function _bashrc_main() {
+    # NOTE: bash does not set primary group ID (PGID) in the environment.
+    GID=$(id -g)
+    export GID
+
     XDG_CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
     export XDG_CACHE_HOME
     XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/.config}"

--- a/bin/all/delete_old_downloads.sh
+++ b/bin/all/delete_old_downloads.sh
@@ -27,7 +27,7 @@ function _main() {
     local days
 
     # Explicitly specify the directories for safety.
-    dirs="${HOME}/tmp/ ${HOME}/Downloads/"
+    dirs="${HOME}/.tmp/ ${HOME}/Downloads/"
 
     days=${1:-""}
 

--- a/bin/all/delete_old_downloads.sh
+++ b/bin/all/delete_old_downloads.sh
@@ -27,7 +27,7 @@ function _main() {
     local days
 
     # Explicitly specify the directories for safety.
-    dirs="${HOME}/.tmp/ ${HOME}/Downloads/"
+    dirs="${HOME}/Downloads/"
 
     days=${1:-""}
 

--- a/bin/all/tmux-sessionizer
+++ b/bin/all/tmux-sessionizer
@@ -97,7 +97,7 @@ function _main() {
     # NOTE: fzf --print-query always prints the query as the first line. If
     #       there is a selection, it will be on the second line.
     IFS=$'\n' readarray -t lines <<<"$(find \
-        "${base_dir}" \
+        "${base_dir}/" \
         -mindepth "${program_options['mindepth']}" \
         -maxdepth "${program_options['maxdepth']}" \
         -type d | fzf --query="${query}" --print-query ${select_option})"
@@ -138,20 +138,25 @@ function _main() {
         selected_name="${selected_name}_"
     fi
 
+    # NOTE: We use cd to change directory rather than using -c option of tmux
+    # new-session and new-window. This is because the -c option expands symlinks
+    # which can lead to unexpected behavior if the base directory includes
+    # symlinks. Using cd preserves the symlink in the session and window starting
+    # directory.
     if [[ -z ${TMUX+x} ]] && [[ -z ${tmux_running} ]]; then
-        tmux new-session -s "${selected_name}" -c "${selected}"
+        tmux new-session -s "${selected_name}" "cd ${selected}; exec ${SHELL}"
         # NOTE: new-session opens the first window.
         for ((i = 2; i <= program_options['windows']; i++)); do
-            tmux new-window -dt "${selected_name}" -c "${selected}"
+            tmux new-window -dt "${selected_name}" "cd ${selected}; exec ${SHELL}"
         done
         return 0
     fi
 
     if ! tmux has-session -t="${selected_name}" 2>/dev/null; then
-        tmux new-session -ds "${selected_name}" -c "${selected}"
+        tmux new-session -ds "${selected_name}" "cd ${selected}; exec ${SHELL}"
         # NOTE: new-session opens the first window.
         for ((i = 2; i <= program_options['windows']; i++)); do
-            tmux new-window -dt "${selected_name}" -c "${selected}"
+            tmux new-window -dt "${selected_name}" "cd ${selected}; exec ${SHELL}"
         done
     fi
 


### PR DESCRIPTION
**Description:**

Create a longer-lived user temporary directory under `/var/tmp` so that it survives reboots. Update the `tw` alias to create workspaces under this directory. This allows the directory to be managed by the system.

**Related Issues:**

- #738

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
