### PR TITLE
chore(deps): downgrade tree-sitter-cli to v0.25.10

### DIFF
--- a/aqua/aqua.yaml
+++ b/aqua/aqua.yaml
@@ -49,7 +49,7 @@ packages:
   - name: sharkdp/bat@v0.26.1
   - name: sharkdp/fd@v10.4.2
   # TODO(#655): Update to v0.26.0+ after dev server issue is resolved
-  - name: tree-sitter/tree-sitter@v0.26.9
+  - name: tree-sitter/tree-sitter@v0.25.10
   - name: kubernetes/kubernetes/kubectl@v1.36.1
   - name: kubernetes/kubernetes/kubeadm@v1.36.1
   - name: kubernetes-sigs/kind@v0.31.0


### PR DESCRIPTION
**Description:**

Downgrade tree-sitter-cli to v0.25.10 to avoid GLIBC errors.

**Related Issues:**

- #655 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
