### PR TITLE
chore: disable the bell via ble.sh

### DIFF
--- a/bash/blesh/init.sh
+++ b/bash/blesh/init.sh
@@ -33,7 +33,7 @@ bleopt exec_elapsed_mark=""
 bleopt exec_elapsed_enabled=""
 #}}}
 
-##{{{ "exec_errexit_mark" specifies the the mark to show the exit status
+##{{{ "exec_errexit_mark" specifies the mark to show the exit status
 ## of the command when it is non-zero.  If this setting is an empty string, the
 ## exit status will not be shown.  The value can contain ANSI escape sequences.
 

--- a/bash/blesh/init.sh
+++ b/bash/blesh/init.sh
@@ -22,16 +22,35 @@
 
 set -o vi
 
-## "exec_errexit_mark" specifies the format of the mark to show the exit status
+##{{{ "edit_bell" controls the behavior of the bell.
+
+bleopt edit_bell=none
+#}}}
+
+##{{{ "exec_elapsed_mark" specifies the format of the execution time report.
+
+bleopt exec_elapsed_mark=""
+bleopt exec_elapsed_enabled=""
+#}}}
+
+##{{{ "exec_errexit_mark" specifies the the mark to show the exit status
 ## of the command when it is non-zero.  If this setting is an empty string, the
 ## exit status will not be shown.  The value can contain ANSI escape sequences.
 
 bleopt exec_errexit_mark=""
+#}}}
 
-## "exec_exit_mark" specifies the marker printed when the bash session ends.
+##{{{ "exec_exit_mark" specifies the marker printed when the bash session ends.
 ## When an empty string is specified, the marker is disabled.
 
 bleopt exec_exit_mark=""
+#}}}
+
+##{{{ "prompt_eol_mark" specifies the contents of the mark used to indicate the
+## command output is not ended with newlines.
+
+bleopt prompt_eol_mark=""
+#}}}
 
 #{{{ ble/widget/discard-and-enter-insert clears the current line.
 function ble/widget/discard-and-enter-insert {


### PR DESCRIPTION
**Description:**

Disable the `ble.sh` `edit_bell`, `exec_elapsed_mark` and `prompt_eol_mark`.

**Related Issues:**

- #796

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
