### PR TITLE
feat(nvim): use bufdel.nvim

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -107,3 +107,6 @@
 [submodule "bash/lib/ble.sh"]
 	path = bash/lib/ble.sh
 	url = https://github.com/akinomyoga/ble.sh.git
+[submodule "nvim/pack/nvim/start/bufdel.nvim"]
+	path = nvim/pack/nvim/start/bufdel.nvim
+	url = https://github.com/wsdjeg/bufdel.nvim.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add [Neovim](https://neovim.io/) as a global tool
   ([#799](https://github.com/ianlewis/dotfiles/issues/799)).
-- Add a ssh config file (`~/.ssh/config`)
+- Add a ssh configuration file (`~/.ssh/config`)
   ([#769](https://github.com/ianlewis/dotfiles/issues/769)).
 - Use [`wsdjeg/bufdel.nvim`](https://github.com/wsdjeg/bufdel.nvim) for
   `<leader>bd` buffer deletion in Neovim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add [Neovim](https://neovim.io/) as a global tool
   ([#799](https://github.com/ianlewis/dotfiles/issues/799)).
+- Add a ssh config file (`~/.ssh/config`)
+  ([#769](https://github.com/ianlewis/dotfiles/issues/769)).
+- Use [`wsdjeg/bufdel.nvim`](https://github.com/wsdjeg/bufdel.nvim) for
+  `<leader>bd` buffer deletion in Neovim
+  ([#801](https://github.com/ianlewis/dotfiles/issues/801)).
 
 ## `2026-06-04`
 

--- a/nvim/lua/ianlewis/remap.lua
+++ b/nvim/lua/ianlewis/remap.lua
@@ -22,10 +22,9 @@ vim.keymap.set({ "n", "v", "o" }, "t", "k")
 vim.keymap.set({ "n", "v", "o" }, "s", "l")
 
 -- Close the current buffer in a split without closing the split itself.
--- This switches to the "previously opened buffer" before closing the original
--- buffer so it could be better as sometimes there isn't really a "previously
--- opened buffer".
-vim.keymap.set({ "n", "v", "o" }, "<leader>bd", ":bp|sp|bn|bd<cr>")
+vim.keymap.set({ "n", "v", "o" }, "<leader>bd", "<cmd>Bdelete<cr>")
+vim.keymap.set({ "n", "v", "o" }, "<leader>bD", "<cmd>Bdelete!<cr>")
+vim.keymap.set({ "n", "v", "o" }, "<leader>bw", "<cmd>Bwipeout<cr>")
 
 -- Open files in the directory of the currently opened file.
 vim.keymap.set("n", "<leader>e", ":e %:h/")


### PR DESCRIPTION
**Description:**

Use [`wsdjeg/bufdel.nvim`](https://github.com/wsdjeg/bufdel.nvim) for `<leader>bd` to delete buffers without changing the window(splits) layout.

**Related Issues:**

- #801

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
