### PR TITLE
feat(tmux,nvim): enable OSC52 clipboard support

### DIFF
--- a/nvim/lua/ianlewis/options.lua
+++ b/nvim/lua/ianlewis/options.lua
@@ -60,15 +60,17 @@ vim.opt.colorcolumn = "+1"
 
 -- If running over SSH, override the clipboard provider to use OSC52
 if vim.env.SSH_TTY then
+	local osc52 = require("vim.ui.clipboard.osc52")
+
 	vim.g.clipboard = {
 		name = "OSC 52",
 		copy = {
-			["+"] = require("vim.ui.clipboard.osc52").copy("+"),
-			["*"] = require("vim.ui.clipboard.osc52").copy("*"),
+			["+"] = osc52.copy("+"),
+			["*"] = osc52.copy("*"),
 		},
 		paste = {
-			["+"] = require("vim.ui.clipboard.osc52").paste("+"),
-			["*"] = require("vim.ui.clipboard.osc52").paste("*"),
+			["+"] = osc52.paste("+"),
+			["*"] = osc52.paste("*"),
 		},
 	}
 end

--- a/nvim/lua/ianlewis/options.lua
+++ b/nvim/lua/ianlewis/options.lua
@@ -57,3 +57,18 @@ vim.opt.textwidth = 80
 -- Set the colorcolumn width. Make it one column right of textwidth so that the
 -- last character doesn't overlap the color column.
 vim.opt.colorcolumn = "+1"
+
+-- If running over SSH, override the clipboard provider to use OSC52
+if vim.env.SSH_TTY then
+	vim.g.clipboard = {
+		name = "OSC 52",
+		copy = {
+			["+"] = require("vim.ui.clipboard.osc52").copy("+"),
+			["*"] = require("vim.ui.clipboard.osc52").copy("*"),
+		},
+		paste = {
+			["+"] = require("vim.ui.clipboard.osc52").paste("+"),
+			["*"] = require("vim.ui.clipboard.osc52").paste("*"),
+		},
+	}
+end

--- a/tmux/_tmux.conf
+++ b/tmux/_tmux.conf
@@ -37,6 +37,9 @@ bind z resize-pane -x 80;
 # Options
 # ----------------------------------------------------------------------------
 
+# Enable OSC52 clipboard support.
+set -s set-clipboard on
+
 # Start windows and panes at 1, not 0
 set -g base-index 1
 setw -g pane-base-index 1


### PR DESCRIPTION
**Description:**

Enable OSC52 clipboard support through `tmux` and Neovim.

**Related Issues:**

- #604 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
