### PR TITLE
feat(bash/sbp): add small bash prompt

### DIFF
--- a/.github/workflows/workflow_call.e2e-test.yml
+++ b/.github/workflows/workflow_call.e2e-test.yml
@@ -111,10 +111,6 @@ jobs:
               libyaml \
               xz \
               tmux
-          # Enable Homebrew's bash as the default shell, which is needed for
-          # installation and testing.
-          sudo bash -c 'echo /opt/homebrew/bin/bash >> /etc/shells'
-          chsh -s /opt/homebrew/bin/bash
 
       - name: e2e-test
         env:

--- a/.github/workflows/workflow_call.e2e-test.yml
+++ b/.github/workflows/workflow_call.e2e-test.yml
@@ -97,6 +97,8 @@ jobs:
       - uses: Homebrew/actions/setup-homebrew@d0dd492210067c1b5f8857ab6c5dd52c29944e44 # main
 
       - name: Install GNU tools
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
           brew install \
               make \
@@ -104,10 +106,15 @@ jobs:
               gnu-getopt \
               grep \
               coreutils \
-              bash-completion \
+              bash \
+              bash-completion@2 \
               libyaml \
               xz \
               tmux
+          # Enable Homebrew's bash as the default shell, which is needed for
+          # installation and testing.
+          sudo bash -c 'echo /opt/homebrew/bin/bash >> /etc/shells'
+          chsh -s /opt/homebrew/bin/bash
 
       - name: e2e-test
         env:

--- a/.github/workflows/workflow_call.unit-test.yml
+++ b/.github/workflows/workflow_call.unit-test.yml
@@ -69,6 +69,8 @@ jobs:
       - uses: Homebrew/actions/setup-homebrew@d0dd492210067c1b5f8857ab6c5dd52c29944e44 # main
 
       - name: Install GNU tools
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
           brew install \
               make \
@@ -76,9 +78,11 @@ jobs:
               gnu-getopt \
               grep \
               coreutils \
-              bash-completion \
+              bash \
+              bash-completion@2 \
               libyaml \
-              xz
+              xz \
+              tmux
 
       - name: unit-test
         env:

--- a/.textlintrc.yaml
+++ b/.textlintrc.yaml
@@ -39,6 +39,7 @@ rules:
       - "/\\be2e\\b/g"
       - "/\\bkubectl\\b/g" # Kubernetes CLI
       - "/\\bmacOS\\b/g"
+      - "/\\b[Aa]llowlists?\\b/g"
       - "/\\b[Cc]hecksums?\\b/g" # e.g. file checksums
       - "/\\b[Dd]otfiles\\b/g"
       - "/\\b[Ff]olke\\b/g"

--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,7 @@ bats-unit: ## Run Bats unit tests.
 	fi; \
 	$(REPO_ROOT)/bash/test/bats/bin/bats \
 		--formatter "$${formatter}" \
+		--recursive \
 		$(REPO_ROOT)/bash/test/unit
 
 $(E2E_HOME)/.installed:

--- a/README.md
+++ b/README.md
@@ -67,12 +67,14 @@ sudo apt-get install -y \
     libssl-dev \
     libyaml-dev \
     make \
+    tmux \
     util-linux \
     zlib1g-dev
 ```
 
 ### macOS
 
+- An updated version of `bash` is required.
 - GNU tools: versions of `make`, `grep`, `awk`, `getopt`, and `mktemp` are
   required.
 - `libyaml`: An installation of `libyaml` is also required to install Ruby.
@@ -87,9 +89,18 @@ brew install \
     gnu-getopt \
     grep \
     coreutils \
+    bash \
     bash-completion@2 \
     libyaml \
+    tmux \
     xz
+```
+
+Add Homebrew's bash to the shell allowlist and enable it as the default shell.
+
+```bash
+sudo bash -c 'echo /opt/homebrew/bin/bash >> /etc/shells'
+chsh -s /opt/homebrew/bin/bash
 ```
 
 ## Install

--- a/bash/sbp/colors.conf
+++ b/bash/sbp/colors.conf
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2034
+
 # Color configuration for the segments.
 # See src/colors/*.bash for the color values
 # All segments colors have default values in src/config/colors.conf
@@ -7,3 +9,14 @@
 # This is how you override them:
 # SEGMENTS_TIMESTAMP_COLOR_PRIMARY=$color2
 # SEGMENTS_TIMESTAMP_COLOR_SECONDARY=$color5
+
+# Set the path_cwd segment's default colors.
+SEGMENTS_PATH_CWD_COLOR_PRIMARY=${SEGMENTS_PATH_CWD_COLOR_PRIMARY:-$color14}
+SEGMENTS_PATH_CWD_COLOR_SECONDARY=${SEGMENTS_PATH_CWD_COLOR_SECONDARY:-$color7}
+SEGMENTS_PATH_CWD_COLOR_SPLITTER=${SEGMENTS_PATH_CWD_COLOR_SPLITTER:-$color4}
+
+# Set the exit code segment's highlight color to color8 and color4 which is
+# typically white on a red background. This is the same as the default color
+# scheme for the "command" segment.
+SEGMENTS_EXIT_CODE_COLOR_PRIMARY_HIGHLIGHT=${SEGMENTS_EXIT_CODE_COLOR_PRIMARY_HIGHLIGHT:-$color8}
+SEGMENTS_EXIT_CODE_COLOR_SECONDARY_HIGHLIGHT=${SEGMENTS_EXIT_CODE_COLOR_SECONDARY_HIGHLIGHT:-$color4}

--- a/bash/sbp/segments/path_cwd.bash
+++ b/bash/sbp/segments/path_cwd.bash
@@ -18,6 +18,6 @@
 # The path_cwd segment displays the current working directory only.
 
 segments::path_cwd() {
-    local wdir=${PWD/${HOME}/\~}
+    local wdir="${PWD/#${HOME}/\~}"
     print_themed_segment 'normal' "$(basename "${wdir}")"
 }

--- a/bash/sbp/segments/path_cwd.bash
+++ b/bash/sbp/segments/path_cwd.bash
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# vim: set ft=bash:
+#
+# Copyright 2026 Ian Lewis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The path_cwd segment displays the current working directory only.
+
+segments::path_cwd() {
+    local wdir=${PWD/${HOME}/\~}
+    print_themed_segment 'normal' "$(basename "${wdir}")"
+}

--- a/bash/sbp/settings.conf
+++ b/bash/sbp/settings.conf
@@ -15,14 +15,18 @@ SBP_HOOKS=('alert')
 # Maybe you don't want to run all segments when in
 # a small window?
 
-if [[ ${COLUMNS} -le 120 ]]; then
+if [[ ${COLUMNS} -le 50 ]]; then
     # Let's adjust to the smaller screen
-    SBP_SEGMENTS_LEFT=('path' 'python_env' 'git' 'exit_code')
+    SBP_SEGMENTS_LEFT=('path_cwd' 'exit_code')
+    SBP_SEGMENTS_LINE_TWO=('prompt_ready')
+elif [[ ${COLUMNS} -le 120 ]]; then
+    # Let's adjust to the smaller screen
+    SBP_SEGMENTS_LEFT=('path' 'path_ro' 'python_env' 'git' 'exit_code')
     SBP_SEGMENTS_LINE_TWO=('prompt_ready')
 else
     # TODO(github.com/brujoand/sbp/issues/135): Enable the k8s segment when it
     #                                           doesn't depend on pcregrep.
-    SBP_SEGMENTS_LEFT=('host' 'path' 'python_env' 'git' 'nix')
+    SBP_SEGMENTS_LEFT=('host' 'path' 'path_ro' 'python_env' 'git' 'nix')
     SBP_SEGMENTS_RIGHT=('command' 'exit_code' 'load' 'timestamp')
     SBP_SEGMENTS_LINE_TWO=('prompt_ready')
 fi

--- a/bash/test/test_helper/sbp/load.bash
+++ b/bash/test/test_helper/sbp/load.bash
@@ -1,0 +1,15 @@
+# Copyright 2026 Ian Lewis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "$(dirname "${BASH_SOURCE[0]}")/segment_helper.bash"

--- a/bash/test/test_helper/sbp/segment_helper.bash
+++ b/bash/test/test_helper/sbp/segment_helper.bash
@@ -1,0 +1,46 @@
+# Copyright 2026 Ian Lewis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source_segment() {
+    local base_path
+    base_path="$(cd "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")")")" >/dev/null 2>&1 && pwd)"
+    local segment_name="${1}"
+
+    segment_source="${base_path}/bash/lib/sbp/src/segments/${segment_name}.bash"
+    if [[ ! -f ${segment_source} ]]; then
+        segment_source="${base_path}/bash/sbp/segments/${segment_name}.bash"
+        if [[ ! -f ${segment_source} ]]; then
+            echo >&2 "Could not find segment ${segment_name}"
+            return 1
+        fi
+    fi
+
+    # shellcheck disable=SC1090
+    source "${segment_source}"
+}
+
+execute_segment() {
+    local segment_name="${1}"
+    source_segment "${segment_name}"
+    "segments::${segment_name}"
+}
+
+print_themed_segment() {
+    for argument in "${@}"; do
+        [[ -z $argument ]] && continue
+        printf '%s\n' "$argument"
+    done
+}
+
+export -f print_themed_segment

--- a/bash/test/test_helper/sbp/segment_helper.bash
+++ b/bash/test/test_helper/sbp/segment_helper.bash
@@ -17,7 +17,7 @@ source_segment() {
     base_path="$(cd "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")")")" >/dev/null 2>&1 && pwd)"
     local segment_name="${1}"
 
-    segment_source="${base_path}/bash/lib/sbp/src/segments/${segment_name}.bash"
+    local segment_source="${base_path}/bash/lib/sbp/src/segments/${segment_name}.bash"
     if [[ ! -f ${segment_source} ]]; then
         segment_source="${base_path}/bash/sbp/segments/${segment_name}.bash"
         if [[ ! -f ${segment_source} ]]; then

--- a/bash/test/unit/segments/path_cwd.bats
+++ b/bash/test/unit/segments/path_cwd.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+# Copyright 2026 Ian Lewis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup() {
+    BASE_PATH="$(cd "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "${BATS_TEST_FILENAME}")")")")")" >/dev/null 2>&1 && pwd)"
+
+    load "${BASE_PATH}/bash/test/test_helper/bats-support/load"
+    load "${BASE_PATH}/bash/test/test_helper/bats-assert/load"
+    load "${BASE_PATH}/bash/test/test_helper/sbp/load"
+}
+
+@test "test a normal path_cwd segment" {
+    cd "${BATS_TEST_TMPDIR}"
+    mapfile -t result <<<"$(execute_segment "path_cwd")"
+
+    # The # of arguments should be 2, the segment type and the base directory
+    # name.
+    assert_equal "${#result[@]}" 2
+    assert_equal "${result[0]}" 'normal'
+    assert_equal "${result[1]}" "$(basename "${BATS_TEST_TMPDIR}")"
+}


### PR DESCRIPTION
**Description:**

Add a short bash prompt for cases where the terminal is less than 50 characters wide. This adds a new `path_cwd` segment that displays only the current base working directory.

- The color of the exit_code segment is changed to red.
- The `path_ro` segment is added to longer prompts.

**Related Issues:**

- #808 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
