### PR TITLE
feat(tmux): adjust status bar based on client_width

### DIFF
--- a/tmux/_tmux.conf
+++ b/tmux/_tmux.conf
@@ -68,9 +68,10 @@ set -g @ram_low_bg_color "darkgreen"
 set -g @ram_medium_bg_color "yellow"
 set -g @ram_high_bg_color "red"
 
-# We need to do a full overwrite of the status-right from tokyonight_moon.tmux
-# to include the cpu/ram values.
-set -g status-right "#[fg=#1e2030,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#1e2030] #{prefix_highlight} #[fg=#3b4261,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#3b4261] %Y-%m-%d  %H:%M #[fg=#{cpu_bg_color},bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#{cpu_bg_color},bold] #{cpu_icon} #{cpu_percentage} #[fg=#{ram_bg_color},bg=#{cpu_bg_color},nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#{ram_bg_color},bold] #{ram_icon} #{ram_percentage} #[fg=#82aaff,bg=#{ram_bg_color},nobold,nounderscore,noitalics]#[fg=#1b1d2b,bg=#82aaff,bold] #h "
+# NOTE: status-left and status-right use tokyonight-moon colors. Colors are
+#       hard-coded and would need to be updated if the theme is changed.
+set -g status-left "#{?#{e|>=|:#{client_width},50},#[fg=#1b1d2b#,bg=#82aaff#,bold] #S #[fg=#82aaff#,bg=#1e2030#,nobold#,nounderscore#,noitalics],}"
+set -g status-right "#{?#{e|>=|:#{client_width},100},#[fg=#1e2030#,bg=#1e2030#,nobold#,nounderscore#,noitalics]#[fg=#82aaff#,bg=#1e2030] #{prefix_highlight} #[fg=#3b4261#,bg=#1e2030#,nobold#,nounderscore#,noitalics]#[fg=#82aaff#,bg=#3b4261] %Y-%m-%d  %H:%M #[fg=#{cpu_bg_color}#,bg=#3b4261#,nobold#,nounderscore#,noitalics]#[fg=#82aaff#,bg=#{cpu_bg_color}#,bold] #{cpu_icon} #{cpu_percentage} #[fg=#{ram_bg_color}#,bg=#{cpu_bg_color}#,nobold#,nounderscore#,noitalics]#[fg=#82aaff#,bg=#{ram_bg_color}#,bold] #{ram_icon} #{ram_percentage} #[fg=#82aaff#,bg=#{ram_bg_color}#,nobold#,nounderscore#,noitalics]#[fg=#1b1d2b#,bg=#82aaff#,bold] #h ,}"
 
 # Plugins
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
**Description:**

Adjust the tmux status bar based on the `client_width` to make it easier for small screens like a phone.

**Related Issues:**

- #808 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
