### PR TITLE
feat(nvim): add lualine extensions

### DIFF
--- a/neovim.yaml
+++ b/neovim.yaml
@@ -129,12 +129,24 @@ structs:
         - type: any # mapped sequence or function: string or function
         - type: table # options
           required: false
+
     keymap.del:
       args:
         - type: any # mode: string or table
         - type: string # key sequence
         - type: table # options
           required: false
+
+    list_extend:
+      args:
+        - type: table # dest
+        - type: table # src
+        - type: number # start
+          required: false
+        - type: number # end
+          required: false
+      returns:
+        type: table # list
 
     # Vim Lua bindings.
     loop:

--- a/nvim/after/plugin/lualine.lua
+++ b/nvim/after/plugin/lualine.lua
@@ -12,8 +12,35 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+local default_config = require("lualine.config").get_config()
+
+-- wordcount_ext is a custom extension for lualine that adds a word count and
+-- character count to the statusline for markdown and text files.
+-- NOTE: Adding sections to an extension overwrites all sections in the default
+--       configuration so we need to merge with the defaults.
+local wordcount_ext = {
+	sections = vim.tbl_deep_extend("force", default_config.sections, {
+		lualine_y = vim.list_extend({
+			function()
+				local wc = vim.fn.wordcount()
+				return string.format("%d:%d", wc.words, wc.chars)
+			end,
+		}, default_config.sections.lualine_y),
+	}),
+	filetypes = {
+		"markdown",
+		"text",
+	},
+}
+
 require("lualine").setup({
 	options = {
 		theme = "tokyonight",
+	},
+	extensions = {
+		-- trouble is a built-in extension that shows the trouble "mode" in the
+		-- statusline for trouble buffers.
+		"trouble",
+		wordcount_ext,
 	},
 })


### PR DESCRIPTION
**Description:**

Add a custom wordcount extension and the built-in `trouble` extension to lualine.

**Related Issues:**

- #829 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
