### PR TITLE
fix(tw): fix creating user tmp on macOS

### DIFF
--- a/bash/_bashrc
+++ b/bash/_bashrc
@@ -237,6 +237,8 @@ function _bashrc_user_temp() {
     local ws_root="${tmp_dir}/dotfiles-user-tmp-${UID}"
     if [[ ! -d ${ws_root} ]]; then
         mkdir -m 0700 "${ws_root}"
+        # NOTE: macOS creates the file with the 'wheel' group.
+        chown "${UID}:${GID}" "$(readlink -f "${ws_root}")"
     fi
 
     # test that the owner, group, and permissions of the workspace directory is
@@ -248,12 +250,10 @@ function _bashrc_user_temp() {
     if [ "$(uname)" == "Darwin" ]; then
         read -r stat_user_id stat_group_id stat_permissions <<<"$(stat -f "%u %g %p" "${ws_root}")"
         stat_permissions="${stat_permissions: -3}"
-        expected_gid="$(dscl . -read /Groups/wheel PrimaryGroupID | cut -d' ' -f2)"
     else
         read -r stat_user_id stat_group_id stat_permissions <<<"$(stat -c "%u %g %a" "${ws_root}")"
-        expected_gid="${GID}"
     fi
-    if [[ ${stat_user_id} != "${UID}" ]] || [[ ${stat_group_id} != "${expected_gid}" ]] || [[ ${stat_permissions} != "700" ]]; then
+    if [[ ${stat_user_id} != "${UID}" ]] || [[ ${stat_group_id} != "${GID}" ]] || [[ ${stat_permissions} != "700" ]]; then
         echo "WARN: Workspace directory ${ws_root} has incorrect ownership or permissions." >&2
         ws_root="$(mktemp -d -t "dotfiles-user-tmp-XXXXXXXXXX")"
     fi
@@ -264,6 +264,7 @@ function _bashrc_user_temp() {
     local user_tmp="${HOME}/.tmp"
     if [[ -L ${user_tmp} ]]; then
         local canon_user_tmp
+        local canon_ws_root
         canon_user_tmp="$(readlink -f "${user_tmp}")"
         canon_ws_root="$(readlink -f "${ws_root}")"
         if [[ ${canon_user_tmp} != "${canon_ws_root}" ]]; then

--- a/bash/_bashrc
+++ b/bash/_bashrc
@@ -245,8 +245,15 @@ function _bashrc_user_temp() {
     local stat_user_id
     local stat_group_id
     local stat_permissions
-    read -r stat_user_id stat_group_id stat_permissions <<<"$(stat -c "%u %g %a" "${ws_root}")"
-    if [[ ${stat_user_id} != "${UID}" ]] || [[ ${stat_group_id} != "${GID}" ]] || [[ ${stat_permissions} != "700" ]]; then
+    if [ "$(uname)" == "Darwin" ]; then
+        read -r stat_user_id stat_group_id stat_permissions <<<"$(stat -f "%u %g %p" "${ws_root}")"
+        stat_permissions="${stat_permissions: -3}"
+        expected_gid="$(dscl . -read /Groups/wheel PrimaryGroupID | cut -d' ' -f2)"
+    else
+        read -r stat_user_id stat_group_id stat_permissions <<<"$(stat -c "%u %g %a" "${ws_root}")"
+        expected_gid="${GID}"
+    fi
+    if [[ ${stat_user_id} != "${UID}" ]] || [[ ${stat_group_id} != "${expected_gid}" ]] || [[ ${stat_permissions} != "700" ]]; then
         echo "WARN: Workspace directory ${ws_root} has incorrect ownership or permissions." >&2
         ws_root="$(mktemp -d -t "dotfiles-user-tmp-XXXXXXXXXX")"
     fi
@@ -258,8 +265,9 @@ function _bashrc_user_temp() {
     if [[ -L ${user_tmp} ]]; then
         local canon_user_tmp
         canon_user_tmp="$(readlink -f "${user_tmp}")"
-        if [[ ${canon_user_tmp} != "${ws_root}" ]]; then
-            echo "WARN: ${user_tmp} is a symlink to ${canon_user_tmp} instead of ${ws_root}. Updating the symlink." >&2
+        canon_ws_root="$(readlink -f "${ws_root}")"
+        if [[ ${canon_user_tmp} != "${canon_ws_root}" ]]; then
+            echo "WARN: ${user_tmp} is a symlink to ${canon_user_tmp} instead of ${canon_ws_root}. Updating the symlink." >&2
             rm -f "${user_tmp}"
             ln -sf "${ws_root}" "${user_tmp}"
         fi


### PR DESCRIPTION
**Description:**

Fix creating the user temporary directory on macOS. Previously the use of `stat` was incorrect on macOs. Directory comparisons were incorrect as `/var/tmp` is a link on macOS.

**Related Issues:**

- Resolves #869 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
